### PR TITLE
refactor(feishu): replace hardcoded bilingual strings with locale module

### DIFF
--- a/.pi/extensions/feishu/bridge-runtime.ts
+++ b/.pi/extensions/feishu/bridge-runtime.ts
@@ -1,6 +1,7 @@
 import { FeishuBridgeStore } from "./bridge-store.js";
 import { FeishuDelivery } from "./delivery.js";
 import { debugLog } from "./debug.js";
+import { msg, t } from "./locale.js";
 
 type PendingScheduledResult = {
   jobId: string;
@@ -72,7 +73,7 @@ export class FeishuBridgeRuntime {
     }
 
     if (details.mode === "subagent_error" && typeof details.error === "string") {
-      await this.deliverOnce(`subagent_error:${jobId}:${message.id || details.error}`, route, `定时任务执行失败：${details.error}`);
+      await this.deliverOnce(`subagent_error:${jobId}:${message.id || details.error}`, route, t("bridge.subagent_error", { error: details.error }));
       return;
     }
 

--- a/.pi/extensions/feishu/cards.ts
+++ b/.pi/extensions/feishu/cards.ts
@@ -1,5 +1,7 @@
+import { msg, t } from "./locale.js";
+
 export function modelLabel(model: any) {
-  if (!model) return "未选择";
+  if (!model) return msg("model.not_selected");
   return `${model.provider}/${model.id}`;
 }
 
@@ -28,7 +30,7 @@ export function buildModelCard(key: string, models: any[], currentModel: any) {
   const elements: any[] = [
     {
       tag: "markdown",
-      content: `当前模型：**${current}**\n点击下面的按钮即可切换当前飞书会话使用的模型。`,
+      content: t("card.current_model.desc", { current }),
     },
   ];
 
@@ -46,7 +48,7 @@ export function buildModelCard(key: string, models: any[], currentModel: any) {
           tag: "button",
           text: {
             tag: "plain_text",
-            content: `${isCurrent ? "当前 " : ""}${model.provider}/${model.id}`,
+            content: `${isCurrent ? msg("card.current_prefix") : ""}${model.provider}/${model.id}`,
           },
           type: isCurrent ? "primary" : "default",
           value: {
@@ -64,23 +66,23 @@ export function buildModelCard(key: string, models: any[], currentModel: any) {
     config: sharedCardConfig(),
     header: {
       template: "blue",
-      title: { tag: "plain_text", content: "选择 Pi 模型" },
+      title: { tag: "plain_text", content: msg("card.select_model.title") },
     },
     elements,
   };
 }
 
 export function buildResumeCard(data: ResumeSessionPage) {
-  const scopeLabel = data.scope === "current" ? "当前项目" : "全部会话";
+  const scopeLabel = data.scope === "current" ? msg("card.resume.scope.current") : msg("card.resume.scope.all");
   const elements: any[] = [
     {
       tag: "markdown",
       content: [
-        `当前视图：**${scopeLabel}**`,
+        t("card.resume.view", { scope: scopeLabel }),
         data.total
-          ? `第 **${data.page + 1} / ${data.totalPages}** 页，共 **${data.total}** 条历史会话。`
-          : "还没有可切换的历史会话。",
-        "点击某条会话后，当前飞书对话会继续接着这条 Pi 会话往下聊。",
+          ? t("card.resume.page_info", { page: data.page + 1, totalPages: data.totalPages, total: data.total })
+          : msg("card.resume.empty"),
+        msg("card.resume.hint"),
       ].join("\n"),
     },
   ];
@@ -95,11 +97,11 @@ export function buildResumeCard(data: ResumeSessionPage) {
 
   for (const item of data.items) {
     const lines = [
-      `**${escapeMarkdown(item.title)}**${item.isCurrent ? " `当前使用中`" : ""}`,
+      `**${escapeMarkdown(item.title)}**${item.isCurrent ? msg("card.resume.current_badge") : ""}`,
       escapeMarkdown(item.subtitle),
-      `更新时间：${escapeMarkdown(item.modifiedLabel)}`,
+      `${msg("card.resume.modified_label")}${escapeMarkdown(item.modifiedLabel)}`,
     ];
-    if (item.workspaceLabel) lines.push(`工作区：${escapeMarkdown(item.workspaceLabel)}`);
+    if (item.workspaceLabel) lines.push(`${msg("card.resume.workspace_label")}${escapeMarkdown(item.workspaceLabel)}`);
     elements.push({
       tag: "markdown",
       content: lines.join("\n"),
@@ -110,7 +112,7 @@ export function buildResumeCard(data: ResumeSessionPage) {
         tag: "button",
         text: {
           tag: "plain_text",
-          content: item.isCurrent ? "当前会话" : "切换到这条会话",
+          content: item.isCurrent ? msg("card.resume.current_session") : msg("card.resume.switch_to"),
         },
         type: item.isCurrent ? "primary" : "default",
         value: {
@@ -129,7 +131,7 @@ export function buildResumeCard(data: ResumeSessionPage) {
     actions: [
       {
         tag: "button",
-        text: { tag: "plain_text", content: "上一页" },
+        text: { tag: "plain_text", content: msg("card.resume.prev_page") },
         type: "default",
         disabled: data.page <= 0,
         value: {
@@ -141,7 +143,7 @@ export function buildResumeCard(data: ResumeSessionPage) {
       },
       {
         tag: "button",
-        text: { tag: "plain_text", content: "下一页" },
+        text: { tag: "plain_text", content: msg("card.resume.next_page") },
         type: "default",
         disabled: data.page >= data.totalPages - 1,
         value: {
@@ -158,7 +160,7 @@ export function buildResumeCard(data: ResumeSessionPage) {
     config: sharedCardConfig(),
     header: {
       template: "turquoise",
-      title: { tag: "plain_text", content: "切换 Pi 历史会话" },
+      title: { tag: "plain_text", content: msg("card.resume.title") },
     },
     elements,
   };
@@ -202,7 +204,7 @@ function buildResumeScopeButton(key: string, scope: ResumeScope, active: boolean
     tag: "button",
     text: {
       tag: "plain_text",
-      content: scope === "current" ? "当前项目" : "全部会话",
+      content: scope === "current" ? msg("card.resume.scope.current") : msg("card.resume.scope.all"),
     },
     type: active ? "primary" : "default",
     value: {

--- a/.pi/extensions/feishu/config.ts
+++ b/.pi/extensions/feishu/config.ts
@@ -14,7 +14,7 @@ export const CHILD_SESSION_ENV = "PI_FEISHU_CHILD_SESSION";
 
 export const DEFAULT_CONFIG: Pick<
   FeishuConfig,
-  "domain" | "groupPolicy" | "cardActionMode" | "cardActionWebhookHost" | "cardActionWebhookPort" | "cardActionWebhookPath" | "language" | "reactEmoji" | "autoStart"
+  "domain" | "groupPolicy" | "cardActionMode" | "cardActionWebhookHost" | "cardActionWebhookPort" | "cardActionWebhookPath" | "reactEmoji" | "autoStart"
 > = {
   domain: "feishu",
   groupPolicy: "open",
@@ -22,7 +22,6 @@ export const DEFAULT_CONFIG: Pick<
   cardActionWebhookHost: "0.0.0.0",
   cardActionWebhookPort: 3001,
   cardActionWebhookPath: "/webhook/card",
-  language: "zh",
   reactEmoji: "THUMBSUP",
   autoStart: true,
 };
@@ -63,7 +62,7 @@ export function loadConfig(): FeishuConfig | undefined {
       cardActionWebhookHost: process.env.FEISHU_CARD_ACTION_WEBHOOK_HOST?.trim() || DEFAULT_CONFIG.cardActionWebhookHost,
       cardActionWebhookPort: parsePort(process.env.FEISHU_CARD_ACTION_WEBHOOK_PORT) ?? DEFAULT_CONFIG.cardActionWebhookPort,
       cardActionWebhookPath: normalizeWebhookPath(process.env.FEISHU_CARD_ACTION_WEBHOOK_PATH) || DEFAULT_CONFIG.cardActionWebhookPath,
-      language: (process.env.FEISHU_LANGUAGE as "zh" | "en") || DEFAULT_CONFIG.language,
+      language: process.env.FEISHU_LANGUAGE === "zh" ? "zh" : process.env.FEISHU_LANGUAGE === "en" ? "en" : undefined,
       reactEmoji: process.env.FEISHU_REACT_EMOJI || DEFAULT_CONFIG.reactEmoji,
       autoStart: process.env.FEISHU_AUTO_START ? process.env.FEISHU_AUTO_START !== "0" : DEFAULT_CONFIG.autoStart,
     };
@@ -80,7 +79,7 @@ export function loadConfig(): FeishuConfig | undefined {
     cardActionWebhookHost: cfg.cardActionWebhookHost || DEFAULT_CONFIG.cardActionWebhookHost,
     cardActionWebhookPort: typeof cfg.cardActionWebhookPort === "number" ? cfg.cardActionWebhookPort : DEFAULT_CONFIG.cardActionWebhookPort,
     cardActionWebhookPath: normalizeWebhookPath(cfg.cardActionWebhookPath) || DEFAULT_CONFIG.cardActionWebhookPath,
-    language: cfg.language || DEFAULT_CONFIG.language,
+    language: cfg.language === "zh" || cfg.language === "en" ? cfg.language : undefined,
     reactEmoji: cfg.reactEmoji || DEFAULT_CONFIG.reactEmoji,
     autoStart: cfg.autoStart ?? DEFAULT_CONFIG.autoStart,
   };

--- a/.pi/extensions/feishu/conversation-manager.ts
+++ b/.pi/extensions/feishu/conversation-manager.ts
@@ -16,6 +16,7 @@ import { debugLog } from "./debug.js";
 import type { ResumeScope, ResumeSessionPage } from "./cards.js";
 import type { TaskStatusSink } from "./task-status-card.js";
 import type { FeishuState } from "./types.js";
+import { msg, t } from "./locale.js";
 
 type ActiveRun = {
   session: AgentSession;
@@ -90,7 +91,7 @@ export class ConversationManager {
           await withTimeout(
             session.prompt(userText, images.length ? { images } : undefined),
             180_000,
-            "Pi 模型处理超时，请稍后重试；如果是图片消息，可以先切换到明确支持图片的模型。",
+            msg("conversation.timeout"),
           );
         } catch (error) {
           if (run.stopped) {
@@ -121,29 +122,29 @@ export class ConversationManager {
   async stopConversation(key: string, onReply: (text: string) => Promise<void>, runId?: string): Promise<StopConversationResult> {
     const active = this.activeRuns.get(key);
     if (!active) {
-      const message = "当前没有进行中的处理。";
+      const message = msg("conversation.not_running");
       await onReply(message);
       return { status: "not_running", message };
     }
     if (runId && active.runId && active.runId !== runId) {
-      const message = "这张任务卡片已不是当前进行中的任务。";
+      const message = msg("conversation.stale_card");
       await onReply(message);
       debugLog("feishu.prompt.stop_stale", { key, runId, activeRunId: active.runId });
       return { status: "stale", message };
     }
 
     active.stopped = true;
-    await active.status?.stopImmediately("用户已停止任务");
+    await active.status?.stopImmediately(msg("conversation.user_stopped"));
     try {
       await active.session.abort();
       debugLog("feishu.prompt.abort", { key });
-      const message = "已停止当前处理。";
+      const message = msg("conversation.stopped");
       await onReply(message);
       return { status: "stopped", message };
     } catch (error) {
       active.stopped = false;
       debugLog("feishu.prompt.abort_error", { key, error: error instanceof Error ? error.message : String(error) });
-      const message = "停止失败，请重试。";
+      const message = msg("conversation.stop_failed");
       await onReply(message);
       return { status: "failed", message };
     }
@@ -159,7 +160,7 @@ export class ConversationManager {
       this.sessions.delete(key);
       delete this.state.sessions[key];
       writeJson(STATE_PATH, this.state);
-      await onReply("已创建新会话。旧会话历史已保留，下一条消息会从新上下文开始。");
+      await onReply(msg("conversation.new_created"));
     }).catch(async (error) => {
       await onReply(`Pi error: ${error instanceof Error ? error.message : String(error)}`);
     });
@@ -182,7 +183,7 @@ export class ConversationManager {
         title: session.name?.trim() || summarizeFirstMessage(session.firstMessage),
         subtitle: session.name?.trim()
           ? summarizeFirstMessage(session.firstMessage)
-          : `消息数：${session.messageCount}`,
+          : t("conversation.message_count", { count: session.messageCount }),
         modifiedLabel: formatModifiedLabel(session.modified),
         workspaceLabel: scope === "all" ? formatWorkspaceLabel(session.cwd) : undefined,
         isCurrent: Boolean(currentSessionPath && sessionPath && currentSessionPath === sessionPath),
@@ -201,7 +202,7 @@ export class ConversationManager {
 
   async resumeConversation(key: string, sessionPathInput: string, onReply: (text: string) => Promise<void>) {
     if (this.activeRuns.has(key)) {
-      await onReply("当前还有进行中的处理，请先发送 /stop，再切换历史会话。");
+      await onReply(msg("conversation.busy_resume"));
       return;
     }
 
@@ -210,7 +211,7 @@ export class ConversationManager {
       const sessionPath = this.normalizeExistingSessionPath(sessionPathInput);
       const sessionInfo = await this.findSessionInfo(sessionPath);
       if (!sessionInfo) {
-        await onReply("这条历史会话不存在，可能已经被删除。请重新打开 /resume 选择。");
+        await onReply(msg("conversation.not_found"));
         return;
       }
 
@@ -218,7 +219,7 @@ export class ConversationManager {
       if (currentPath === sessionPath) {
         this.state.workspaces![key] = sessionInfo.cwd || this.getWorkspace(key);
         writeJson(STATE_PATH, this.state);
-        await onReply(`你已经在这个历史会话里了。\n当前工作区：${this.state.workspaces![key]}`);
+        await onReply(`${msg("conversation.already_in")}\n${t("conversation.current_workspace", { path: this.state.workspaces![key] })}`);
         return;
       }
 
@@ -232,9 +233,9 @@ export class ConversationManager {
       this.state.workspaces![key] = sessionInfo.cwd || this.cwd;
       writeJson(STATE_PATH, this.state);
       await onReply([
-        `已切换到历史会话：${sessionInfo.name?.trim() || summarizeFirstMessage(sessionInfo.firstMessage)}`,
-        `工作区：${this.state.workspaces![key]}`,
-        "下一条消息会继续接着这个会话往下聊。",
+        t("conversation.switched_session", { name: sessionInfo.name?.trim() || summarizeFirstMessage(sessionInfo.firstMessage) }),
+        t("conversation.workspace_label", { path: this.state.workspaces![key] }),
+        msg("conversation.next_message"),
       ].join("\n"));
     }).catch(async (error) => {
       await onReply(`Pi error: ${error instanceof Error ? error.message : String(error)}`);
@@ -248,7 +249,7 @@ export class ConversationManager {
     const next = previous.then(async () => {
       const model = this.modelRegistry.find(provider, modelId);
       if (!model || !this.modelRegistry.hasConfiguredAuth(model)) {
-        await onReply(`这个模型当前不可用：${provider}/${modelId}。请发送 /model 重新选择。`);
+        await onReply(t("conversation.model_unavailable", { model: `${provider}/${modelId}` }));
         return;
       }
 
@@ -260,7 +261,7 @@ export class ConversationManager {
         try { (await cached).dispose(); } catch {}
       }
       this.sessions.delete(key);
-      await onReply(`已切换到 ${provider}/${modelId}。当前飞书会话后续都会使用这个模型。`);
+      await onReply(t("conversation.model_switched", { model: `${provider}/${modelId}` }));
     }).catch(async (error) => {
       await onReply(`Pi error: ${error instanceof Error ? error.message : String(error)}`);
     });
@@ -276,9 +277,9 @@ export class ConversationManager {
     if (!workspaceInput) {
       const current = this.getWorkspace(key);
       await onReply([
-        `当前工作区：${current}`,
-        "用法：/workspace /绝对路径",
-        "也支持：/workspace ~/your/project",
+        t("conversation.workspace_current", { path: current }),
+        msg("conversation.workspace_usage"),
+        msg("conversation.workspace_tilde"),
       ].join("\n"));
       return;
     }
@@ -294,7 +295,7 @@ export class ConversationManager {
       delete this.state.sessions[key];
       this.state.workspaces![key] = workspace;
       writeJson(STATE_PATH, this.state);
-      await onReply(`已切换到工作区：${workspace}\n下一条消息会在这个目录里创建新的 Pi 会话。`);
+      await onReply(`${t("conversation.workspace_switched", { path: workspace })}\n${msg("conversation.workspace_next")}`);
     }).catch(async (error) => {
       await onReply(error instanceof Error ? error.message : `Pi error: ${String(error)}`);
     });
@@ -350,7 +351,7 @@ export class ConversationManager {
 
   private previousTurn(key: string) {
     const previous = this.queues.get(key) || Promise.resolve();
-    return withTimeout(previous, 120_000, "上一条飞书消息处理超时，已跳过等待。")
+    return withTimeout(previous, 120_000, msg("conversation.queue_timeout"))
       .catch((error) => {
         debugLog("feishu.queue.previous_timeout", {
           key,
@@ -440,7 +441,7 @@ export class ConversationManager {
 
   private normalizeExistingSessionPath(path: string) {
     if (!path || !existsSync(path)) {
-      throw new Error("历史会话不存在，可能已经被删除。");
+      throw new Error(msg("conversation.not_found_deleted"));
     }
     return realpathSync(path);
   }
@@ -488,7 +489,7 @@ function extractLastAssistantText(session: AgentSession): string {
 function resolveWorkspacePath(input: string) {
   const trimmed = input.trim();
   if (!trimmed) {
-    throw new Error("请在 /workspace 后面带上目录路径，例如：/workspace /Users/ax/project");
+    throw new Error(msg("conversation.workspace_usage_detail"));
   }
 
   const expanded = trimmed === "~" || trimmed.startsWith("~/")
@@ -496,7 +497,7 @@ function resolveWorkspacePath(input: string) {
     : trimmed;
 
   if (!isAbsolute(expanded)) {
-    throw new Error("当前只支持绝对路径或 ~/ 开头的路径。");
+    throw new Error(msg("conversation.workspace_absolute_only"));
   }
 
   const resolved = resolve(expanded);
@@ -506,30 +507,30 @@ function resolveWorkspacePath(input: string) {
 
 function ensureWorkspaceExists(path: string) {
   if (!existsSync(path)) {
-    throw new Error(`工作区不存在：${path}`);
+    throw new Error(t("conversation.workspace_not_exist", { path }));
   }
 
   let stat;
   try {
     stat = statSync(path);
   } catch {
-    throw new Error(`无法访问工作区：${path}`);
+    throw new Error(t("conversation.workspace_not_accessible", { path }));
   }
 
   if (!stat.isDirectory()) {
-    throw new Error(`工作区不是目录：${path}`);
+    throw new Error(t("conversation.workspace_not_dir", { path }));
   }
 }
 
 function summarizeFirstMessage(text: string) {
   const normalized = (text || "").replace(/\s+/g, " ").trim();
-  if (!normalized) return "未命名会话";
+  if (!normalized) return msg("conversation.unnamed_session");
   return normalized.length > 36 ? `${normalized.slice(0, 35)}...` : normalized;
 }
 
 function formatModifiedLabel(value: Date | string) {
   const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) return "未知";
+  if (Number.isNaN(date.getTime())) return msg("conversation.unknown_date");
   const yyyy = date.getFullYear();
   const mm = String(date.getMonth() + 1).padStart(2, "0");
   const dd = String(date.getDate()).padStart(2, "0");

--- a/.pi/extensions/feishu/index.ts
+++ b/.pi/extensions/feishu/index.ts
@@ -1,9 +1,9 @@
 import { existsSync, mkdirSync, openSync, readFileSync, rmSync, statSync } from "node:fs";
-import { spawn, spawnSync } from "node:child_process";
+import { execSync, spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { buildModelCard, buildResumeCard, parseModelActionValue, parseResumePageActionValue, parseResumeSelectActionValue } from "./cards.js";
-import { BRIDGE_PATH, CHILD_SESSION_ENV, CONFIG_PATH, DAEMON_LOG_PATH, DEBUG_LOG_PATH, DEDUPE_PATH, ensureRoot, loadConfig, mask, removePath, STATE_PATH, writeJson } from "./config.js";
+import { BRIDGE_PATH, CHILD_SESSION_ENV, CONFIG_PATH, DAEMON_LOG_PATH, DEBUG_LOG_PATH, DEDUPE_PATH, ensureRoot, getBashPath, loadConfig, mask, removePath, STATE_PATH, writeJson } from "./config.js";
 import { debugLog } from "./debug.js";
 import { FeishuBridgeRuntime } from "./bridge-runtime.js";
 import { FeishuBridgeStore } from "./bridge-store.js";
@@ -15,6 +15,7 @@ import { runSetup, uiConfirm } from "./setup.js";
 import { buildTaskStatusCard, parseStopTaskActionValue } from "./task-status-card.js";
 import { BotUnavailableError, FeishuTransport } from "./transport.js";
 import type { FeishuConfig, FeishuStatus } from "./types.js";
+import { invalidateLocale, msg, t } from "./locale.js";
 
 export default function feishuExtension(pi: ExtensionAPI) {
   if (process.env[CHILD_SESSION_ENV] === "1") {
@@ -54,12 +55,12 @@ export default function feishuExtension(pi: ExtensionAPI) {
 
   function statusText(brand: "Feishu" | "Lark", status: FeishuStatus) {
     const labels: Record<FeishuStatus, string> = {
-      "not configured": "未配置 / Not configured",
-      connecting: "连接中 / Connecting",
-      connected: "已连接 / Connected",
-      disconnected: "已断开 / Disconnected",
-      owned: "连接被占用 / In use by another process",
-      "bot unavailable": "机器人不可用 / Bot unavailable",
+      "not configured": msg("status.not_configured"),
+      connecting: msg("status.connecting"),
+      connected: msg("status.connected"),
+      disconnected: msg("status.disconnected"),
+      owned: msg("status.owned"),
+      "bot unavailable": msg("status.bot_unavailable"),
     };
     return withBuildTag(`${brand}: ${labels[status]}`);
   }
@@ -118,7 +119,7 @@ export default function feishuExtension(pi: ExtensionAPI) {
     const cfg = config || loadConfig();
     if (!cfg) {
       updateStatus("not configured");
-      throw new Error(`Missing config. Run /feishu setup first. 配置不存在，请先运行 /feishu setup。`);
+      throw new Error(msg("status.missing_config"));
     }
     updateStatus("connecting");
     const lockResult = await acquireGatewayLock(process.cwd(), Boolean(options.takeover));
@@ -141,7 +142,7 @@ export default function feishuExtension(pi: ExtensionAPI) {
       const copy = parseCopyMarkdownActionValue(action.value);
       if (copy) {
         const source = transport?.getMarkdownCopySource(copy.copySourceId);
-        await transport?.replyPlainText(action.messageId, source || "MD 原文已过期，请重新生成卡片。");
+        await transport?.replyPlainText(action.messageId, source || msg("card.copy.stale"));
         return;
       }
       const stopTask = parseStopTaskActionValue(action.value);
@@ -225,10 +226,10 @@ export default function feishuExtension(pi: ExtensionAPI) {
 
   function notifyDaemonStartResult(ctx: any, result: Awaited<ReturnType<typeof startDaemon>>) {
     if (result.status === "busy") {
-      ctx.ui.notify(withBuildTag(`飞书连接已在后台运行。\n${formatOwner(result.owner)}`), "info");
+      ctx.ui.notify(withBuildTag(t("notify.daemon_already_running", { owner: formatOwner(result.owner) })), "info");
       return;
     }
-    ctx.ui.notify(withBuildTag(`飞书连接已启动。\nGateway pid=${result.pid}\nLog: ${DAEMON_LOG_PATH}`), "info");
+    ctx.ui.notify(withBuildTag(t("notify.daemon_started", { pid: result.pid, path: DAEMON_LOG_PATH })), "info");
   }
 
   function quoteShell(value: string) {
@@ -259,7 +260,7 @@ export default function feishuExtension(pi: ExtensionAPI) {
   async function startDaemon(takeover = false) {
     return withDaemonSpawnLock(async () => {
       const cfg = loadConfig();
-      if (!cfg) throw new Error(`Missing config. Run /feishu setup first. 配置不存在，请先运行 /feishu setup。`);
+      if (!cfg) throw new Error(msg("status.missing_config"));
       let owner = readGatewayOwner();
       if (owner && owner.pid !== process.pid && !takeover) {
         return { status: "busy" as const, owner };
@@ -282,13 +283,16 @@ export default function feishuExtension(pi: ExtensionAPI) {
       reapDetachedDaemonProcesses({ keepPids: [process.pid] });
       ensureRoot();
       const logFd = openSync(DAEMON_LOG_PATH, "a");
-      const child = spawn("bash", ["-lc", daemonCommand()], {
+      const child = spawn(getBashPath(cfg), ["-lc", daemonCommand()], {
         detached: true,
         cwd: process.cwd(),
         env: { ...process.env, PI_FEISHU_DAEMON: "1" },
         stdio: ["ignore", logFd, logFd],
       });
       child.unref();
+      child.on("error", (err) => {
+        console.error("[feishu] daemon spawn error:", err.message);
+      });
 
       await sleep(1500);
       return { status: "started" as const, pid: child.pid, owner: readGatewayOwner() };
@@ -307,13 +311,18 @@ export default function feishuExtension(pi: ExtensionAPI) {
       return { status: "stopped-current" as const };
     }
     try {
-      process.kill(owner.pid, "SIGTERM");
+      if (process.platform === "win32") {
+        killDaemonParentWindows(owner.pid);
+      } else {
+        process.kill(owner.pid, "SIGTERM");
+      }
       await sleep(800);
-      reapDetachedDaemonProcesses();
       return { status: "stopped" as const, owner };
     } catch (error) {
       return { status: "error" as const, owner, error };
-    }
+    } finally {
+      reapDetachedDaemonProcesses();
+  }
   }
 
   async function restartDaemon() {
@@ -334,6 +343,7 @@ export default function feishuExtension(pi: ExtensionAPI) {
           const configToStart = await runSetup(ctx);
           if (configToStart) {
             writeJson(CONFIG_PATH, configToStart);
+          invalidateLocale();
             notifyDaemonStartResult(ctx, await startDaemon(false));
           }
           refreshStatusFromState();
@@ -347,11 +357,12 @@ export default function feishuExtension(pi: ExtensionAPI) {
         if (cmd === "stop") {
           const result = await stopDaemon();
           if (result.status === "error") {
-            ctx.ui.notify(`停止飞书连接失败：${result.error instanceof Error ? result.error.message : String(result.error)}\nOwner: ${formatOwner(result.owner)}`, "error");
+            ctx.ui.notify(t("notify.stop_failed", { error: result.error instanceof Error ? result.error.message : String(result.error), owner: formatOwner(result.owner) }), "error");
             refreshStatusFromState();
             return;
           }
-          ctx.ui.notify(result.status === "none" ? "飞书连接未在运行。" : "飞书连接已停止。", "info");
+          updateStatus("disconnected");
+          ctx.ui.notify(result.status === "none" ? msg("notify.not_running") : msg("notify.stopped"), "info");
           refreshStatusFromState();
           return;
         }
@@ -359,26 +370,27 @@ export default function feishuExtension(pi: ExtensionAPI) {
           const result = await restartDaemon();
           if (result.status === "error") {
             const stopped = result.stopped;
-            ctx.ui.notify(`飞书连接重启失败：${stopped.error instanceof Error ? stopped.error.message : String(stopped.error)}\nOwner: ${formatOwner(stopped.owner)}`, "error");
+            ctx.ui.notify(t("notify.restart_failed", { error: stopped.error instanceof Error ? stopped.error.message : String(stopped.error), owner: formatOwner(stopped.owner) }), "error");
             refreshStatusFromState();
             return;
           }
-          ctx.ui.notify(`飞书连接已重启，最新代码和配置已生效。\nOwner: ${formatOwner(result.started.owner)}\nLog: ${DAEMON_LOG_PATH}`, "info");
+          ctx.ui.notify(t("notify.restarted", { owner: formatOwner(result.started.owner), path: DAEMON_LOG_PATH }), "info");
           refreshStatusFromState();
           return;
         }
         if (cmd === "reset") {
           const ok = await uiConfirm(
             ctx,
-            "确认重置飞书扩展？会删除配置和会话映射，但保留所有会话历史。 / Reset Feishu extension? This deletes config and conversation mappings, but keeps all session history.",
+            msg("notify.reset_confirm"),
             false,
           );
           if (!ok) {
-            ctx.ui.notify("Reset cancelled / 已取消重置", "info");
+            ctx.ui.notify(msg("notify.reset_cancelled"), "info");
             return;
           }
           await stopDaemon();
           removePath(CONFIG_PATH);
+          invalidateLocale();
           removePath(STATE_PATH);
           removePath(DEDUPE_PATH);
           removePath(`${DEDUPE_PATH}.lock`);
@@ -387,10 +399,7 @@ export default function feishuExtension(pi: ExtensionAPI) {
           messageHandler.reset();
           ensureRoot();
           updateStatus("not configured");
-          ctx.ui.notify(
-            "Feishu extension reset. Session history was kept. Run /feishu setup. / 飞书扩展已重置，会话历史已保留，请运行 /feishu setup。",
-            "info",
-          );
+          ctx.ui.notify(msg("notify.reset_done"), "info");
           refreshStatusFromState();
           return;
         }
@@ -400,7 +409,7 @@ export default function feishuExtension(pi: ExtensionAPI) {
           const owner = gatewayLock?.owner || readGatewayOwner();
           ctx.ui.notify(
             [
-              `Status: ${lastStatusText || (loadConfig() ? "Feishu: disconnected" : "Feishu: not configured")}`,
+              t("notify.status_line", { text: lastStatusText || (loadConfig() ? "Feishu: disconnected" : "Feishu: not configured") }),
               `Gateway owner: ${formatOwner(owner)}`,
               `Config: ${cfg ? `${cfg.domain}, appId=${mask(cfg.appId)}, groupPolicy=${cfg.groupPolicy}, autoStart=${cfg.autoStart !== false}` : "missing"}`,
               `Path: ${CONFIG_PATH}`,
@@ -414,7 +423,7 @@ export default function feishuExtension(pi: ExtensionAPI) {
         }
         if (cmd === "debug") {
           if (!existsSync(DEBUG_LOG_PATH)) {
-            ctx.ui.notify("还没有飞书调试日志。请先在飞书里发一条消息给机器人。", "info");
+            ctx.ui.notify(msg("notify.no_debug_log"), "info");
             return;
           }
           const lines = readFileSync(DEBUG_LOG_PATH, "utf8").trim().split("\n").slice(-20);
@@ -424,16 +433,17 @@ export default function feishuExtension(pi: ExtensionAPI) {
         if (cmd === "autostart") {
           const cfg = loadConfig();
           if (!cfg) {
-            ctx.ui.notify("Missing config. Run /feishu setup first.", "warning");
+            ctx.ui.notify(msg("notify.missing_config_warning"), "warning");
             return;
           }
           cfg.autoStart = cfg.autoStart === false;
           writeJson(CONFIG_PATH, cfg);
-          ctx.ui.notify(cfg.autoStart ? "飞书自动启动已开启。" : "飞书自动启动已关闭。", "info");
+          invalidateLocale();
+          ctx.ui.notify(cfg.autoStart ? msg("notify.autostart_on") : msg("notify.autostart_off"), "info");
           refreshStatusFromState();
           return;
         }
-        ctx.ui.notify("可用命令：/feishu setup | start | stop | restart | status | debug | autostart | reset", "info");
+        ctx.ui.notify(msg("notify.commands_hint"), "info");
       } catch (error) {
         ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
       }
@@ -447,24 +457,24 @@ export default function feishuExtension(pi: ExtensionAPI) {
     startStatusRefresh();
   });
 
-  if (bootConfig?.autoStart !== false) {
-    if (process.env.PI_FEISHU_DAEMON === "1") {
-      start().then((result) => {
-        if (typeof result === "object" && result.status === "owned") {
-          console.error("[feishu] daemon found existing owner, exiting:", formatOwner(result.owner));
-          process.exit(0);
-        }
-      }).catch((error) => {
-        updateStatus(error instanceof BotUnavailableError ? "bot unavailable" : "disconnected");
-        console.error("[feishu] daemon autoStart failed:", error instanceof Error ? error.message : error);
-        process.exit(1);
-      });
-    } else {
-      startDaemon(false).catch((error) => {
-        updateStatus("disconnected");
-        console.error("[feishu] daemon spawn failed:", error instanceof Error ? error.message : error);
-      });
-    }
+  if (process.env.PI_FEISHU_DAEMON === "1") {
+    // Daemon always connects regardless of autoStart.
+    // autoStart only controls whether the TUI auto-spawns the daemon.
+    start().then((result) => {
+      if (typeof result === "object" && result.status === "owned") {
+        console.error("[feishu] daemon found existing owner, exiting:", formatOwner(result.owner));
+        process.exit(0);
+      }
+    }).catch((error) => {
+      updateStatus(error instanceof BotUnavailableError ? "bot unavailable" : "disconnected");
+      console.error("[feishu] daemon autoStart failed:", error instanceof Error ? error.message : error);
+      process.exit(1);
+    });
+  } else if (bootConfig?.autoStart !== false) {
+    startDaemon(false).catch((error) => {
+      updateStatus("disconnected");
+      console.error("[feishu] daemon spawn failed:", error instanceof Error ? error.message : error);
+    });
   }
 
   pi.on("session_shutdown", async () => {
@@ -488,7 +498,10 @@ type DaemonProcessInfo = {
 };
 
 function reapDetachedDaemonProcesses(options: { keepPids?: number[]; extensionPath?: string } = {}) {
-  if (process.platform === "win32") return;
+  if (process.platform === "win32") {
+    reapDetachedDaemonProcessesWindows(options);
+    return;
+  }
 
   const keep = new Set(options.keepPids || []);
   const allProcesses = listProcesses();
@@ -523,23 +536,126 @@ function collectDescendantPids(pid: number, byParent: Map<number, DaemonProcessI
   }
 }
 
-function listProcesses() {
-  const result = spawnSync("ps", ["-wwaxo", "pid=,ppid=,command="], { encoding: "utf8" });
-  if (result.status !== 0) return [] as DaemonProcessInfo[];
+function reapDetachedDaemonProcessesWindows(options: { keepPids?: number[]; extensionPath?: string } = {}) {
+  const keep = new Set(options.keepPids || []);
+  const allProcesses = listProcesses();
+  if (!allProcesses.length) return;
 
-  const processes: DaemonProcessInfo[] = [];
-  for (const line of result.stdout.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    const match = trimmed.match(/^(\d+)\s+(\d+)\s+(.*)$/);
-    if (!match) continue;
-    const pid = Number(match[1]);
-    const ppid = Number(match[2]);
-    const command = match[3] || "";
-    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
-    processes.push({ pid, ppid, command });
+  // Build pid→parent and parent→children lookups
+  const pidToPpid = new Map<number, number>();
+  const byParent = new Map<number, DaemonProcessInfo[]>();
+  for (const proc of allProcesses) {
+    pidToPpid.set(proc.pid, proc.ppid);
+    const siblings = byParent.get(proc.ppid) || [];
+    siblings.push(proc);
+    byParent.set(proc.ppid, siblings);
   }
-  return processes;
+
+  // Find feishu daemon roots
+  const roots = allProcesses.filter((proc) => looksLikeFeishuDaemon(proc.command, options.extensionPath));
+  if (!roots.length) {
+    // Daemon already dead — try finding orphan bash launcher processes directly
+    // (they contain "tail -f /dev/null" and "feishu" but aren't the daemon itself)
+    const orphanLaunchers = allProcesses.filter((proc) =>
+      proc.command.includes("tail -f /dev/null") && proc.command.includes("feishu")
+      && !proc.command.includes("--mode rpc")
+    );
+    if (orphanLaunchers.length) {
+      const toKill = new Set<number>();
+      for (const proc of orphanLaunchers) {
+        if (keep.has(proc.pid)) continue;
+        toKill.add(proc.pid);
+        collectDescendantPids(proc.pid, byParent, toKill, keep);
+      }
+      for (const pid of [...toKill].sort((a, b) => b - a)) {
+        if (keep.has(pid) || pid === process.pid) continue;
+        try { execSync(`taskkill /F /PID ${pid}`, { encoding: "utf8", timeout: 3000, windowsHide: true }); } catch {}
+      }
+    }
+    return;
+  }
+
+  const toKill = new Set<number>();
+  for (const proc of roots) {
+    if (keep.has(proc.pid)) continue;
+    toKill.add(proc.pid);
+    // Collect all descendant processes (children, grandchildren, etc.)
+    collectDescendantPids(proc.pid, byParent, toKill, keep);
+    // Also kill the daemon's parent (bash launcher) and grandparent chain
+    let ppid = proc.ppid;
+    while (ppid > 1 && ppid !== process.pid && !keep.has(ppid)) {
+      const ppidCmd = allProcesses.find((p) => p.pid === ppid)?.command || "";
+      if (!ppidCmd.includes("tail -f /dev/null") && !ppidCmd.includes("feishu")) break;
+      toKill.add(ppid);
+      ppid = pidToPpid.get(ppid) || 0;
+    }
+  }
+
+  // Kill: taskkill /F for each PID (children before parents via descending sort)
+  for (const pid of [...toKill].sort((a, b) => b - a)) {
+    if (keep.has(pid) || pid === process.pid) continue;
+    try {
+      execSync(`taskkill /F /PID ${pid}`, { encoding: "utf8", timeout: 3000, windowsHide: true });
+    } catch {
+      // Process may already be dead
+    }
+  }
+}
+
+function listProcesses(): DaemonProcessInfo[] {
+  if (process.platform === "win32") {
+    return listProcessesWindows();
+  }
+  const result = spawnSync("ps", ["-wwaxo", "pid=,ppid=,command="], { encoding: "utf8" });
+  if (result.status !== 0 && result.status !== null) return [];
+  return result.stdout.split("\n")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => {
+      const pidEnd = entry.indexOf(" ");
+      if (pidEnd === -1) return undefined;
+      const pid = Number(entry.slice(0, pidEnd));
+      const rest = entry.slice(pidEnd + 1).trimStart();
+      const ppidEnd = rest.indexOf(" ");
+      if (ppidEnd === -1) return undefined;
+      const ppid = Number(rest.slice(0, ppidEnd));
+      if (!Number.isFinite(pid) || !Number.isFinite(ppid)) return undefined;
+      return { pid, ppid, command: rest.slice(ppidEnd + 1).trimStart() };
+    })
+    .filter((entry): entry is DaemonProcessInfo => entry !== undefined);
+}
+
+function listProcessesWindows(): DaemonProcessInfo[] {
+  try {
+    const result = spawnSync("wmic", [
+      "process", "get", "ProcessId,ParentProcessId,CommandLine", "/FORMAT:LIST",
+    ], { encoding: "utf8", timeout: 5000, windowsHide: true });
+    if (result.status !== 0 && result.status !== null) return [];
+    const lines = result.stdout.split("\n");
+    const processes: DaemonProcessInfo[] = [];
+    let pid = 0, ppid = 0, command = "";
+    for (const raw of lines) {
+      const line = raw.trimEnd();
+      if (line.startsWith("ProcessId=")) {
+        pid = Number(line.slice("ProcessId=".length));
+      } else if (line.startsWith("ParentProcessId=")) {
+        ppid = Number(line.slice("ParentProcessId=".length));
+      } else if (line.startsWith("CommandLine=")) {
+        command = line.slice("CommandLine=".length);
+      } else if (line === "") {
+        if (Number.isFinite(pid) && Number.isFinite(ppid) && pid > 0) {
+          processes.push({ pid, ppid, command });
+        }
+        pid = 0; ppid = 0; command = "";
+      }
+    }
+    if (Number.isFinite(pid) && Number.isFinite(ppid) && pid > 0) {
+      processes.push({ pid, ppid, command });
+    }
+    return processes;
+  } catch {
+    return [];
+  }
 }
 
 function looksLikeFeishuDaemon(command: string, extensionPath?: string) {
@@ -552,21 +668,56 @@ function looksLikeFeishuDaemon(command: string, extensionPath?: string) {
 }
 
 function terminateLauncherParent() {
-  if (process.platform === "win32") return;
   const parentPid = process.ppid;
   if (!parentPid || parentPid <= 1) return;
-
-  const result = spawnSync("ps", ["-wwaxo", "pid=,command="], { encoding: "utf8" });
-  if (result.status !== 0) return;
-
-  const line = result.stdout.split("\n")
-    .map((entry) => entry.trim())
-    .find((entry) => entry.startsWith(`${parentPid} `));
-  if (!line) return;
-  if (!line.includes("tail -f /dev/null") || !line.includes("feishu/index.ts")) return;
-  try { process.kill(parentPid, "SIGTERM"); } catch {}
+  if (process.platform !== "win32") {
+    const result = spawnSync("ps", ["-wwaxo", "pid=,command="], { encoding: "utf8" });
+    if (result.status !== 0 && result.status !== null) return;
+    const line = result.stdout.split("\n")
+      .map((entry) => entry.trim())
+      .find((entry) => entry.startsWith(`${parentPid} `));
+    if (!line) return;
+    if (!line.includes("tail -f /dev/null") || !line.includes("feishu")) return;
+    try { process.kill(parentPid, "SIGTERM"); } catch {}
+    return;
+  }
+  // Windows: kill the launcher bash process and its child tree
+  try {
+    const result = execSync(
+      `wmic process where "ProcessId=${parentPid}" get CommandLine /FORMAT:LIST`,
+      { encoding: "utf8", timeout: 3000, windowsHide: true },
+    );
+    const cmdMatch = result.match(/^CommandLine=(.*)$/m);
+    const cmdLine = cmdMatch ? cmdMatch[1].trim() : "";
+    if (cmdLine.includes("tail -f /dev/null") && cmdLine.includes("feishu")) {
+      execSync(`taskkill /F /PID ${parentPid}`, { encoding: "utf8", timeout: 3000, windowsHide: true });
+    }
+  } catch {}
 }
 
+/**
+ * Windows: Kill the daemon's parent bash process, which kills the entire
+ * process tree (bash + tail + pi daemon) in one shot. Called BEFORE the
+ * daemon PID is killed, so wmic can still find the parent relationship.
+ */
+function killDaemonParentWindows(daemonPid: number) {
+  try {
+    const result = execSync(
+      `wmic process where "ProcessId=${daemonPid}" get ParentProcessId /FORMAT:LIST`,
+      { encoding: "utf8", timeout: 3000, windowsHide: true },
+    );
+    const match = result.match(/^ParentProcessId=(\d+)/m);
+    const ppid = match ? Number(match[1]) : 0;
+    if (Number.isFinite(ppid) && ppid > 1 && ppid !== daemonPid && ppid !== process.pid) {
+      execSync(`taskkill /F /T /PID ${ppid}`, { encoding: "utf8", timeout: 3000, windowsHide: true });
+      return;
+    }
+  } catch {
+    // Parent not found; fall through to killing just the daemon
+  }
+  // Fallback: kill just the daemon process (no /T here since it has no children worth tracking)
+  execSync(`taskkill /F /PID ${daemonPid}`, { encoding: "utf8", timeout: 3000, windowsHide: true });
+}
 async function withDaemonSpawnLock<T>(fn: () => Promise<T>): Promise<T> {
   const lockPath = `${gatewayLockPath()}.spawn.lock`;
   for (let attempt = 0; attempt < 40; attempt += 1) {

--- a/.pi/extensions/feishu/locale.ts
+++ b/.pi/extensions/feishu/locale.ts
@@ -1,0 +1,353 @@
+import { loadConfig } from "./config.js";
+
+export type Locale = "zh" | "en";
+
+const _cache: { locale?: Locale } = {};
+
+/** Detect the effective locale — config override → terminal env (LANG) → "en" default */
+export function getLocale(): Locale {
+  if (_cache.locale) return _cache.locale;
+
+  // Config override takes precedence
+  const cfg = loadConfig();
+  if (cfg?.language === "zh" || cfg?.language === "en") {
+    _cache.locale = cfg.language;
+    return _cache.locale;
+  }
+
+  // Detect from terminal locale
+  // Unix: LANG, LC_ALL, LC_MESSAGES
+  // Windows (Git Bash/MSYS2): LANG is typically set
+  const lang = process.env.LANG || process.env.LC_ALL || process.env.LC_MESSAGES || "";
+  _cache.locale = lang.startsWith("zh") ? "zh" : "en";
+  return _cache.locale;
+}
+
+/** Invalidate cached locale (call after config changes or language switch) */
+export function invalidateLocale() {
+  delete _cache.locale;
+}
+
+/** Check if current locale is Chinese */
+export function isZh(): boolean {
+  return getLocale() === "zh";
+}
+
+/** Get a translated string for the current locale (simple key lookup) */
+export function msg(key: string): string {
+  const locale = getLocale();
+  return (TRANSLATIONS[locale] as Record<string, string>)[key] || (TRANSLATIONS.en as Record<string, string>)[key] || key;
+}
+
+/**
+ * Get a translated string with interpolation.
+ * Placeholders use `${name}` syntax.
+ * @example t("当前模型：**${current}**", { current: "openai/gpt-4" })
+ */
+export function t(template: string, vars?: Record<string, string | number>): string {
+  const locale = getLocale();
+  let text = (TRANSLATIONS[locale] as Record<string, string>)[template];
+  if (text === undefined) text = (TRANSLATIONS.en as Record<string, string>)[template];
+  if (text === undefined) text = template;
+  if (!vars) return text;
+  return text.replace(/\$\{(\w+)\}/g, (_, key) => String(vars[key] ?? `\${${key}}`));
+}
+
+/** Join error messages with locale-appropriate separator */
+export function joinErrors(errors: string[]): string {
+  return errors.join(getLocale() === "zh" ? "；" : "; ");
+}
+
+// ============================================================
+// All translations — flat key → { zh, en } entries
+// ============================================================
+
+const TRANSLATIONS: Record<Locale, Record<string, string>> = {
+  zh: {
+    // ============= cards.ts =============
+    "model.not_selected": "未选择",
+    "card.select_model.title": "选择 Pi 模型",
+    "card.current_model.desc": "当前模型：**${current}**\n点击下面的按钮即可切换当前飞书会话使用的模型。",
+    "card.current_prefix": "当前 ",
+    "card.resume.scope.current": "当前项目",
+    "card.resume.scope.all": "全部会话",
+    "card.resume.view": "当前视图：**${scope}**",
+    "card.resume.page_info": "第 **${page} / ${totalPages}** 页，共 **${total}** 条历史会话。",
+    "card.resume.empty": "还没有可切换的历史会话。",
+    "card.resume.hint": "点击某条会话后，当前飞书对话会继续接着这条 Pi 会话往下聊。",
+    "card.resume.current_badge": " `当前使用中`",
+    "card.resume.modified_label": "更新时间：",
+    "card.resume.workspace_label": "工作区：",
+    "card.resume.current_session": "当前会话",
+    "card.resume.switch_to": "切换到这条会话",
+    "card.resume.prev_page": "上一页",
+    "card.resume.next_page": "下一页",
+    "card.resume.title": "切换 Pi 历史会话",
+
+    // ============= conversation-manager.ts =============
+    "conversation.timeout": "Pi 模型处理超时，请稍后重试；如果是图片消息，可以先切换到明确支持图片的模型。",
+    "conversation.not_running": "当前没有进行中的处理。",
+    "conversation.stale_card": "这张任务卡片已不是当前进行中的任务。",
+    "conversation.user_stopped": "用户已停止任务",
+    "conversation.stopped": "已停止当前处理。",
+    "conversation.stop_failed": "停止失败，请重试。",
+    "conversation.new_created": "已创建新会话。旧会话历史已保留，下一条消息会从新上下文开始。",
+    "conversation.message_count": "消息数：${count}",
+    "conversation.busy_resume": "当前还有进行中的处理，请先发送 /stop，再切换历史会话。",
+    "conversation.not_found": "这条历史会话不存在，可能已经被删除。请重新打开 /resume 选择。",
+    "conversation.already_in": "你已经在这个历史会话里了。",
+    "conversation.current_workspace": "当前工作区：${path}",
+    "conversation.switched_session": "已切换到历史会话：${name}",
+    "conversation.workspace_label": "工作区：${path}",
+    "conversation.next_message": "下一条消息会继续接着这个会话往下聊。",
+    "conversation.model_unavailable": "这个模型当前不可用：${model}。请发送 /model 重新选择。",
+    "conversation.model_switched": "已切换到 ${model}。当前飞书会话后续都会使用这个模型。",
+    "conversation.workspace_current": "当前工作区：${path}",
+    "conversation.workspace_usage": "用法：/workspace /绝对路径",
+    "conversation.workspace_tilde": "也支持：/workspace ~/your/project",
+    "conversation.workspace_switched": "已切换到工作区：${path}",
+    "conversation.workspace_next": "下一条消息会在这个目录里创建新的 Pi 会话。",
+    "conversation.queue_timeout": "上一条飞书消息处理超时，已跳过等待。",
+    "conversation.not_found_deleted": "历史会话不存在，可能已经被删除。",
+    "conversation.workspace_usage_detail": "请在 /workspace 后面带上目录路径，例如：/workspace /Users/ax/project",
+    "conversation.workspace_absolute_only": "当前只支持绝对路径或 ~/ 开头的路径。",
+    "conversation.workspace_not_exist": "工作区不存在：${path}",
+    "conversation.workspace_not_accessible": "无法访问工作区：${path}",
+    "conversation.workspace_not_dir": "工作区不是目录：${path}",
+    "conversation.unnamed_session": "未命名会话",
+    "conversation.unknown_date": "未知",
+
+    // ============= task-status-card.ts =============
+    "task.phase.starting": "开始处理",
+    "task.phase.still_running": "仍在处理",
+    "task.phase.current": "当前阶段：${phase}",
+    "task.button.stop": "停止任务",
+    "task.status.done": "任务完成",
+    "task.status.failed": "任务失败",
+    "task.status.stopped": "任务已停止",
+    "task.status.inactive": "任务已结束",
+    "task.status.running": "任务进行中",
+    "task.final_phase.failed": "处理失败",
+    "task.final_phase.stopped": "用户已停止任务",
+
+    // ============= message-handler.ts =============
+    "handler.image.unsupported_model": "当前模型不支持图片解析。请先发送 /model 并切换到支持图片的模型后，再重发图片。",
+    "handler.no_content": "没有可处理的内容：${errors}",
+    "handler.model.none": "当前没有可用模型。请先在 Pi 里完成模型登录或 API Key 配置。",
+    "handler.image.download_unavailable": "飞书连接不可用，图片无法下载",
+    "handler.image.download_timeout": "图片下载超时",
+    "handler.image.unsupported_format": "图片格式暂不支持（仅支持 png/jpg/webp）",
+    "handler.image.download_failed": "图片下载失败",
+    "handler.file.unsupported_type": "文件类型不支持：${name}",
+    "handler.file.download_unavailable": "飞书连接不可用，文件无法下载：${name}",
+    "handler.file.download_timeout": "文件下载超时：${name}",
+    "handler.file.unreadable": "文件无法按文本读取：${name}",
+    "handler.file.download_failed": "文件下载失败：${name}",
+    "handler.file.truncated": "\n[内容过长，已截断]",
+    "handler.file.section": "[Feishu file: ${name}]\n\`\`\`${language}\n${text}\n\`\`\`",
+    "handler.prompt.analyze_image": "请根据图片内容进行分析。",
+    "handler.prompt.image_hint": "[提示：当前模型不支持图片，本次仅处理文本/文件内容。]",
+    "handler.prompt.attachment_errors": "[部分附件未处理：${errors}]",
+
+    // ============= messages.ts =============
+    "msg.label.p2p": "[飞书私聊]",
+    "msg.label.thread": "[飞书话题]",
+    "msg.label.group": "[飞书群聊]",
+
+    // ============= index.ts =============
+    "status.not_configured": "未配置",
+    "status.connecting": "连接中",
+    "status.connected": "已连接",
+    "status.disconnected": "已断开",
+    "status.owned": "连接被占用",
+    "status.bot_unavailable": "机器人不可用",
+    "status.missing_config": "配置不存在，请先运行 /feishu setup。",
+    "card.copy.stale": "MD 原文已过期，请重新生成卡片。",
+    "notify.daemon_already_running": "飞书连接已在后台运行。\n${owner}",
+    "notify.daemon_started": "飞书连接已启动。\n网关 pid=${pid}\n日志：${path}",
+    "notify.stop_failed": "停止飞书连接失败：${error}\n所有者：${owner}",
+    "notify.not_running": "飞书连接未在运行。",
+    "notify.stopped": "飞书连接已停止。",
+    "notify.restart_failed": "飞书连接重启失败：${error}\n所有者：${owner}",
+    "notify.restarted": "飞书连接已重启，最新代码和配置已生效。\n所有者：${owner}\n日志：${path}",
+    "notify.reset_confirm": "确认重置飞书扩展？会删除配置和会话映射，但保留所有会话历史。",
+    "notify.reset_cancelled": "已取消重置",
+    "notify.reset_done": "飞书扩展已重置，会话历史已保留，请运行 /feishu setup。",
+    "notify.status_line": "状态：${text}",
+    "notify.no_debug_log": "还没有飞书调试日志。请先在飞书里发一条消息给机器人。",
+    "notify.missing_config_warning": "配置不存在，请先运行 /feishu setup。",
+    "notify.autostart_on": "飞书自动启动已开启。",
+    "notify.autostart_off": "飞书自动启动已关闭。",
+    "notify.commands_hint": "可用命令：/feishu setup | start | stop | restart | status | debug | autostart | reset",
+
+    // ============= rich-text.ts =============
+    "rich_text.copy_button": "返回MD原文",
+    "rich_text.title_fallback": "Pi 回复",
+
+    // ============= setup.ts =============
+    "setup.method.title": "配置方式",
+    "setup.method.auto": "扫码自动创建飞书助手",
+    "setup.method.manual": "手动填写已有应用",
+    "setup.domain.title": "应用区域",
+    "setup.domain.feishu": "Feishu 中国",
+    "setup.domain.lark": "Lark 国际",
+    "setup.app_id": "应用 ID",
+    "setup.app_secret": "应用密钥",
+    "setup.group_policy.title": "群聊策略",
+    "setup.group_policy.open": "不需要 @，群/话题消息自动回复",
+    "setup.group_policy.mention": "只有 @ 机器人才回复",
+    "setup.saved": "飞书配置已保存\n路径：${path}\nApp ID：${id}\n群聊策略：${policy}",
+    "setup.start_confirm": "现在启动飞书连接？",
+    // ============= bridge-runtime.ts =============
+    "bridge.subagent_error": "定时任务执行失败：${error}",
+    "setup.preparing_qr": "正在准备飞书授权二维码...",
+    "setup.qr_scan_hint": "请在终端扫描二维码，或打开终端中显示的链接。",
+    "setup.qr_header": "\n飞书/Lark 授权二维码",
+    "setup.qr_expire": "二维码 ${expireIn} 秒后过期",
+    "setup.lark_detected": "检测到 Lark 租户，正在切换区域。",
+  },
+
+  en: {
+    // ============= cards.ts =============
+    "model.not_selected": "Not selected",
+    "card.select_model.title": "Select Pi Model",
+    "card.current_model.desc": "Current model: **${current}**\nClick a button below to switch the model used by this Feishu conversation.",
+    "card.current_prefix": "",
+    "card.resume.scope.current": "Current project",
+    "card.resume.scope.all": "All sessions",
+    "card.resume.view": "Current view: **${scope}**",
+    "card.resume.page_info": "Page **${page} / ${totalPages}**, **${total}** sessions total.",
+    "card.resume.empty": "No historical sessions available.",
+    "card.resume.hint": "Click a session to continue that Pi conversation in this Feishu chat.",
+    "card.resume.current_badge": " `current`",
+    "card.resume.modified_label": "Updated: ",
+    "card.resume.workspace_label": "Workspace: ",
+    "card.resume.current_session": "Current session",
+    "card.resume.switch_to": "Switch to this session",
+    "card.resume.prev_page": "Previous",
+    "card.resume.next_page": "Next",
+    "card.resume.title": "Switch Pi Session",
+
+    // ============= conversation-manager.ts =============
+    "conversation.timeout": "Pi model processing timed out. Please retry later; if you sent an image, try switching to a model that supports images first.",
+    "conversation.not_running": "No processing is currently in progress.",
+    "conversation.stale_card": "This task card is no longer the currently active task.",
+    "conversation.user_stopped": "User stopped the task",
+    "conversation.stopped": "Stopped the current processing.",
+    "conversation.stop_failed": "Stop failed. Please try again.",
+    "conversation.new_created": "Created a new session. The previous session history has been preserved. The next message will start with a fresh context.",
+    "conversation.message_count": "Messages: ${count}",
+    "conversation.busy_resume": "Processing is still in progress. Please send /stop first, then switch sessions.",
+    "conversation.not_found": "That historical session does not exist — it may have been deleted. Please open /resume again to select.",
+    "conversation.already_in": "You are already in this historical session.",
+    "conversation.current_workspace": "Current workspace: ${path}",
+    "conversation.switched_session": "Switched to historical session: ${name}",
+    "conversation.workspace_label": "Workspace: ${path}",
+    "conversation.next_message": "The next message will continue this session.",
+    "conversation.model_unavailable": "Model is currently unavailable: ${model}. Send /model to select another one.",
+    "conversation.model_switched": "Switched to ${model}. This Feishu conversation will use this model going forward.",
+    "conversation.workspace_current": "Current workspace: ${path}",
+    "conversation.workspace_usage": "Usage: /workspace /absolute/path",
+    "conversation.workspace_tilde": "Also supported: /workspace ~/your/project",
+    "conversation.workspace_switched": "Switched to workspace: ${path}",
+    "conversation.workspace_next": "The next message will create a new Pi session in this directory.",
+    "conversation.queue_timeout": "Previous Feishu message processing timed out, skipped waiting.",
+    "conversation.not_found_deleted": "Historical session does not exist — it may have been deleted.",
+    "conversation.workspace_usage_detail": "Usage: /workspace <absolute-path>",
+    "conversation.workspace_absolute_only": "Only absolute paths or ~/ relative paths are supported.",
+    "conversation.workspace_not_exist": "Workspace does not exist: ${path}",
+    "conversation.workspace_not_accessible": "Cannot access workspace: ${path}",
+    "conversation.workspace_not_dir": "Workspace is not a directory: ${path}",
+    "conversation.unnamed_session": "Unnamed session",
+    "conversation.unknown_date": "Unknown",
+
+    // ============= task-status-card.ts =============
+    "task.phase.starting": "Starting",
+    "task.phase.still_running": "Still processing",
+    "task.phase.current": "Current phase: ${phase}",
+    "task.button.stop": "Stop",
+    "task.status.done": "Task complete",
+    "task.status.failed": "Task failed",
+    "task.status.stopped": "Task stopped",
+    "task.status.inactive": "Task ended",
+    "task.status.running": "Task in progress",
+    "task.final_phase.failed": "Processing failed",
+    "task.final_phase.stopped": "User stopped the task",
+
+    // ============= message-handler.ts =============
+    "handler.image.unsupported_model": "The current model does not support image analysis. Send /model to switch to a model that supports images, then resend the image.",
+    "handler.no_content": "No processable content: ${errors}",
+    "handler.model.none": "No models available. Please log in or configure API keys in Pi first.",
+    "handler.image.download_unavailable": "Feishu connection unavailable, cannot download image",
+    "handler.image.download_timeout": "Image download timed out",
+    "handler.image.unsupported_format": "Image format not supported (only png/jpg/webp)",
+    "handler.image.download_failed": "Image download failed",
+    "handler.file.unsupported_type": "File type not supported: ${name}",
+    "handler.file.download_unavailable": "Feishu connection unavailable, cannot download file: ${name}",
+    "handler.file.download_timeout": "File download timed out: ${name}",
+    "handler.file.unreadable": "Could not read file as text: ${name}",
+    "handler.file.download_failed": "File download failed: ${name}",
+    "handler.file.truncated": "\n[Content too long, truncated]",
+    "handler.file.section": "[Feishu file: ${name}]\n\`\`\`${language}\n${text}\n\`\`\`",
+    "handler.prompt.analyze_image": "Please analyze the image content provided.",
+    "handler.prompt.image_hint": "[Note: current model does not support images; processing text/file content only.]",
+    "handler.prompt.attachment_errors": "[Some attachments were not processed: ${errors}]",
+
+    // ============= messages.ts =============
+    "msg.label.p2p": "[Feishu DM]",
+    "msg.label.thread": "[Feishu thread]",
+    "msg.label.group": "[Feishu group]",
+
+    // ============= index.ts =============
+    "status.not_configured": "Not configured",
+    "status.connecting": "Connecting",
+    "status.connected": "Connected",
+    "status.disconnected": "Disconnected",
+    "status.owned": "In use by another process",
+    "status.bot_unavailable": "Bot unavailable",
+    "status.missing_config": "Missing config. Run /feishu setup first.",
+    "card.copy.stale": "MD source is outdated. Please regenerate the card.",
+    "notify.daemon_already_running": "Feishu connection is already running in the background.\n${owner}",
+    "notify.daemon_started": "Feishu connection started.\nGateway pid=${pid}\nLog: ${path}",
+    "notify.stop_failed": "Failed to stop Feishu connection: ${error}\nOwner: ${owner}",
+    "notify.not_running": "Feishu connection is not running.",
+    "notify.stopped": "Feishu connection has stopped.",
+    "notify.restart_failed": "Failed to restart Feishu connection: ${error}\nOwner: ${owner}",
+    "notify.restarted": "Feishu connection restarted. Latest code and config are active.\nOwner: ${owner}\nLog: ${path}",
+    "notify.reset_confirm": "Reset Feishu extension? This will delete config and conversation mappings, but keep all session history.",
+    "notify.reset_cancelled": "Reset cancelled.",
+    "notify.reset_done": "Feishu extension reset. Session history was kept. Run /feishu setup.",
+    "notify.status_line": "Status: ${text}",
+    "notify.no_debug_log": "No Feishu debug log yet. Send a message to the bot first.",
+    "notify.missing_config_warning": "Missing config. Run /feishu setup first.",
+    "notify.autostart_on": "Feishu auto-start has been enabled.",
+    "notify.autostart_off": "Feishu auto-start has been disabled.",
+    "notify.commands_hint": "Available commands: /feishu setup | start | stop | restart | status | debug | autostart | reset",
+
+    // ============= rich-text.ts =============
+    "rich_text.copy_button": "View MD source",
+    "rich_text.title_fallback": "Pi reply",
+
+    // ============= setup.ts =============
+    "setup.method.title": "Setup method",
+    "setup.method.auto": "Create by QR code",
+    "setup.method.manual": "Configure existing app",
+    "setup.domain.title": "App region",
+    "setup.domain.feishu": "Feishu China",
+    "setup.domain.lark": "Lark Global",
+    "setup.app_id": "App ID",
+    "setup.app_secret": "App Secret",
+    "setup.group_policy.title": "Group policy",
+    "setup.group_policy.open": "Open — auto reply in groups/topics without @",
+    "setup.group_policy.mention": "Mention — reply only when the bot is @mentioned",
+    "setup.saved": "Feishu config saved\nPath: ${path}\nApp ID: ${id}\nGroup policy: ${policy}",
+    "setup.start_confirm": "Start Feishu now?",
+    // ============= bridge-runtime.ts =============
+    "bridge.subagent_error": "Subagent task failed: ${error}",
+    "setup.preparing_qr": "Preparing Feishu authorization QR code...",
+    "setup.qr_scan_hint": "Scan the QR code in terminal, or open the link printed there.",
+    "setup.qr_header": "\nFeishu/Lark authorization QR code",
+    "setup.qr_expire": "QR code expires in ${expireIn} seconds.",
+    "setup.lark_detected": "Detected Lark tenant; switching domain.",
+  },
+};

--- a/.pi/extensions/feishu/message-handler.ts
+++ b/.pi/extensions/feishu/message-handler.ts
@@ -8,6 +8,8 @@ import { TaskStatusCard } from "./task-status-card.js";
 import type { FeishuBridgeStore } from "./bridge-store.js";
 import type { FeishuTransport } from "./transport.js";
 import type { FeishuMessage } from "./types.js";
+import { joinErrors, msg, t } from "./locale.js";
+
 
 const CONTENT_DEDUPE_TTL_MS = 5_000;
 
@@ -85,14 +87,14 @@ export class FeishuMessageHandler {
       if (skippedImageCount > 0 && imageInputs.length === 0 && !fileSections.length && !text.trim()) {
         await transport.replyText(
           msg.messageId,
-          "当前模型不支持图片解析。请先发送 /model 并切换到支持图片的模型后，再重发图片。",
+          msg("handler.image.unsupported_model"),
         );
         await markFeishuMessage(msg.messageId, "replied");
         return;
       }
 
       if (downloadErrors.length && !imageInputs.length && !fileSections.length && !text.trim()) {
-        await transport.replyText(msg.messageId, `没有可处理的内容：${downloadErrors.join("；")}`);
+        await transport.replyText(msg.messageId, t("handler.no_content", { errors: joinErrors(downloadErrors) }));
         await markFeishuMessage(msg.messageId, "replied");
         return;
       }
@@ -129,7 +131,7 @@ export class FeishuMessageHandler {
     if (command.name === "model") {
       const models = this.conversations.getAvailableModels();
       if (!models.length) {
-        await transport.replyText(msg.messageId, "当前没有可用模型。请先在 Pi 里完成模型登录或 API Key 配置。");
+        await transport.replyText(msg.messageId, msg("handler.model.none"));
         return true;
       }
       const currentModel = await this.conversations.getSelectedModel(key);
@@ -189,18 +191,18 @@ export class FeishuMessageHandler {
           continue;
         }
         if (!transport) {
-          downloadErrors.push("飞书连接不可用，图片无法下载");
+          downloadErrors.push(msg("handler.image.download_unavailable"));
           continue;
         }
         try {
           const resource = await withTimeout(
             transport.downloadImage(msg.messageId, attachment.fileKey),
             15000,
-            "图片下载超时",
+            msg("handler.image.download_timeout"),
           );
           const mimeType = detectImageMime(resource.bytes, resource.mimeType);
           if (!isSupportedImageMime(mimeType)) {
-            downloadErrors.push("图片格式暂不支持（仅支持 png/jpg/webp）");
+            downloadErrors.push(msg("handler.image.unsupported_format"));
             continue;
           }
           imageInputs.push({
@@ -214,36 +216,36 @@ export class FeishuMessageHandler {
             fileKey: attachment.fileKey,
             error: error instanceof Error ? error.message : String(error),
           });
-          downloadErrors.push(error instanceof Error ? error.message : "图片下载失败");
+          downloadErrors.push(error instanceof Error ? error.message : msg("handler.image.download_failed"));
         }
         continue;
       }
 
       const fileName = attachment.fileName || "unnamed";
       if (!isSupportedTextFile(fileName)) {
-        downloadErrors.push(`文件类型不支持：${fileName}`);
+        downloadErrors.push(t("handler.file.unsupported_type", { name: fileName }));
         continue;
       }
       if (!transport) {
-        downloadErrors.push(`飞书连接不可用，文件无法下载：${fileName}`);
+        downloadErrors.push(t("handler.file.download_unavailable", { name: fileName }));
         continue;
       }
       try {
         const resource = await withTimeout(
           transport.downloadMessageResource(msg.messageId, attachment.fileKey, "file"),
           15000,
-          `文件下载超时：${fileName}`,
+          t("handler.file.download_timeout", { name: fileName }),
         );
         const decoded = decodeTextFile(fileName, resource.bytes);
         if (!decoded.ok) {
-          downloadErrors.push(`文件无法按文本读取：${fileName}`);
+          downloadErrors.push(t("handler.file.unreadable", { name: fileName }));
           continue;
         }
         const language = detectCodeLanguage(fileName);
-        const suffix = decoded.truncated ? "\n[内容过长，已截断]" : "";
-        fileSections.push(`[Feishu file: ${fileName}]\n\`\`\`${language}\n${decoded.text}${suffix}\n\`\`\``);
+        const suffix = decoded.truncated ? msg("handler.file.truncated") : "";
+        fileSections.push(t("handler.file.section", { name: fileName, language, text: decoded.text }) + suffix);
       } catch (error) {
-        downloadErrors.push(error instanceof Error ? error.message : `文件下载失败：${fileName}`);
+        downloadErrors.push(error instanceof Error ? error.message : t("handler.file.download_failed", { name: fileName }));
       }
     }
 
@@ -264,15 +266,15 @@ function buildPrompt(
   if (text.trim()) contentParts.push(text.trim());
   if (fileSections.length) contentParts.push(fileSections.join("\n\n"));
   if (!contentParts.length && imageInputs.length) {
-    contentParts.push("请根据图片内容进行分析。");
+    contentParts.push(msg("handler.prompt.analyze_image"));
   }
 
   if (skippedImageCount > 0 && !modelSupportsImage) {
-    contentParts.push("[提示：当前模型不支持图片，本次仅处理文本/文件内容。]");
+    contentParts.push(msg("handler.prompt.image_hint"));
   }
 
   if (downloadErrors.length) {
-    contentParts.push(`[部分附件未处理：${downloadErrors.join("；")}]`);
+    contentParts.push(t("handler.prompt.attachment_errors", { errors: joinErrors(downloadErrors) }));
   }
 
   const promptBody = contentParts.join("\n\n").trim();

--- a/.pi/extensions/feishu/messages.ts
+++ b/.pi/extensions/feishu/messages.ts
@@ -1,4 +1,5 @@
 import type { FeishuAttachment, FeishuMessage } from "./types.js";
+import { msg } from "./locale.js";
 
 export type BotCommand =
   | { name: "new" }
@@ -31,9 +32,9 @@ export function conversationKey(msg: FeishuMessage) {
 }
 
 export function conversationLabel(msg: FeishuMessage) {
-  if (msg.chatType === "p2p") return "[飞书私聊]";
-  if (msg.rootId || msg.parentId || msg.threadId || msg.chatMode === "topic") return "[飞书话题]";
-  return "[飞书群聊]";
+  if (msg.chatType === "p2p") return msg("msg.label.p2p");
+  if (msg.rootId || msg.parentId || msg.threadId || msg.chatMode === "topic") return msg("msg.label.thread");
+  return msg("msg.label.group");
 }
 
 export function parseMessageInput(msg: FeishuMessage, botOpenId?: string): { text: string; attachments: FeishuAttachment[] } {

--- a/.pi/extensions/feishu/rich-text.ts
+++ b/.pi/extensions/feishu/rich-text.ts
@@ -1,4 +1,5 @@
 type LocaleKey = "zh_cn" | "en_us";
+import { getLocale, msg } from "./locale.js";
 
 type PostTextElement = {
   tag: "text";
@@ -47,19 +48,19 @@ export function chooseMessageMode(text: string): FeishuMessageMode {
   return "text";
 }
 
-export function buildMarkdownCard(text: string, language: "zh" | "en" = "zh") {
+export function buildMarkdownCard(text: string, language: "zh" | "en" = getLocale()) {
   const trimmed = text.trim() || "(empty response)";
-  const { title, body } = extractMarkdownTitle(trimmed, language);
+  const { title, body } = extractMarkdownTitle(trimmed);
   return createMarkdownCard(title, body || trimmed);
 }
 
-export function buildMarkdownCards(text: string, language: "zh" | "en" = "zh") {
+export function buildMarkdownCards(text: string, language: "zh" | "en" = getLocale()) {
   return buildMarkdownCardParts(text, language).map((part) => part.card);
 }
 
-export function buildMarkdownCardParts(text: string, language: "zh" | "en" = "zh", copySourceId?: (index: number) => string): MarkdownCardPart[] {
+export function buildMarkdownCardParts(text: string, language: "zh" | "en" = getLocale(), copySourceId?: (index: number) => string): MarkdownCardPart[] {
   const trimmed = text.trim() || "(empty response)";
-  const { title, body } = extractMarkdownTitle(trimmed, language);
+  const { title, body } = extractMarkdownTitle(trimmed);
   const withCopyButton = Boolean(copySourceId);
   const fullCard = createMarkdownCard(title, body || trimmed, withCopyButton ? "__copy_source_id__" : undefined);
   if (byteSize(fullCard) < MAX_CARD_BYTES) {
@@ -95,7 +96,7 @@ function createMarkdownCard(title: string, content: string, copySourceId?: strin
           tag: "button",
           text: {
             tag: "plain_text",
-            content: "返回MD原文",
+            content: msg("rich_text.copy_button"),
           },
           type: "default",
           width: "default",
@@ -130,11 +131,11 @@ function analyzeText(text: string) {
   };
 }
 
-export function buildPostMessages(text: string, language: "zh" | "en" = "zh") {
+export function buildPostMessages(text: string, language: "zh" | "en" = getLocale()) {
   return splitText(text.trim() || "(empty response)", MAX_POST_CHARS).map((chunk, index, chunks) => {
-    const parsed = markdownToPost(chunk, language);
+    const parsed = markdownToPost(chunk);
     const title = chunks.length > 1 ? `${parsed.title} (${index + 1}/${chunks.length})` : parsed.title;
-    const locale = language === "en" ? "en_us" : "zh_cn";
+    const locale = getLocale() === "zh" ? "zh_cn" : "en_us";
     const post = {
       title,
       content: parsed.content.length ? parsed.content : [[{ tag: "text", text: chunk }]],
@@ -160,12 +161,12 @@ function looksLikeMarkdown(text: string) {
   ].some((pattern) => pattern.test(text));
 }
 
-function markdownToPost(text: string, language: "zh" | "en") {
+function markdownToPost(text: string) {
   const lines = text.replace(/\r\n/g, "\n").split("\n");
   const titleIndex = lines.findIndex((line) => line.trim());
   const firstLine = titleIndex >= 0 ? lines[titleIndex].trim() : "";
   const heading = firstLine.match(/^#{1,6}\s+(.+)$/);
-  const title = cleanInlineMarkdown(heading?.[1] || firstLine || (language === "en" ? "Pi reply" : "Pi 回复")).slice(0, 120);
+  const title = cleanInlineMarkdown(heading?.[1] || firstLine || msg("rich_text.title_fallback")).slice(0, 120);
   const content: PostElement[][] = [];
   let inCodeBlock = false;
 
@@ -213,13 +214,13 @@ function markdownToPost(text: string, language: "zh" | "en") {
   return { title, content };
 }
 
-function extractMarkdownTitle(text: string, language: "zh" | "en") {
+function extractMarkdownTitle(text: string) {
   const lines = text.replace(/\r\n/g, "\n").split("\n");
   const titleIndex = lines.findIndex((line) => line.trim());
-  if (titleIndex < 0) return { title: language === "en" ? "Pi reply" : "Pi 回复", body: text };
+  if (titleIndex < 0) return { title: msg("rich_text.title_fallback"), body: text };
   const firstLine = lines[titleIndex].trim();
   const heading = firstLine.match(/^#{1,6}\s+(.+)$/);
-  const title = cleanInlineMarkdown(heading?.[1] || firstLine || (language === "en" ? "Pi reply" : "Pi 回复")).slice(0, 120);
+  const title = cleanInlineMarkdown(heading?.[1] || firstLine || msg("rich_text.title_fallback")).slice(0, 120);
   const body = lines
     .filter((_, index) => index !== titleIndex)
     .join("\n")

--- a/.pi/extensions/feishu/setup.ts
+++ b/.pi/extensions/feishu/setup.ts
@@ -2,6 +2,7 @@ import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import qrcode from "qrcode-terminal";
 import { CONFIG_PATH, DEFAULT_CONFIG, ensureRoot, mask, writeJson } from "./config.js";
 import type { Domain, FeishuConfig, GroupPolicy } from "./types.js";
+import { msg, t } from "./locale.js";
 
 export async function uiSelect<T extends string>(ctx: ExtensionCommandContext, title: string, options: Array<{ value: T; label: string }>, initialValue?: T): Promise<T> {
   const ui: any = ctx.ui;
@@ -34,10 +35,10 @@ export async function uiConfirm(ctx: ExtensionCommandContext, title: string, ini
 export async function runSetup(ctx: ExtensionCommandContext) {
   ensureRoot();
   const mode = await uiSelect(ctx,
-    "配置方式 / Setup method",
+    msg("setup.method.title"),
     [
-      { value: "auto", label: "扫码自动创建飞书助手 / Create by QR code" },
-      { value: "manual", label: "手动填写已有应用 / Configure existing app" },
+      { value: "auto", label: msg("setup.method.auto") },
+      { value: "manual", label: msg("setup.method.manual") },
     ],
     "auto",
   );
@@ -53,22 +54,22 @@ export async function runSetup(ctx: ExtensionCommandContext) {
     domain = created.domain;
   } else {
     domain = await uiSelect(ctx,
-      "应用区域 / App region",
+      msg("setup.domain.title"),
       [
-        { value: "feishu", label: "Feishu 中国 / Feishu China" },
-        { value: "lark", label: "Lark 国际 / Lark Global" },
+        { value: "feishu", label: msg("setup.domain.feishu") },
+        { value: "lark", label: msg("setup.domain.lark") },
       ],
       "feishu",
     );
-    appId = (await uiInput(ctx, "App ID / 应用 ID")).trim();
-    appSecret = (await uiInput(ctx, "App Secret / 应用密钥")).trim();
+    appId = (await uiInput(ctx, msg("setup.app_id"))).trim();
+    appSecret = (await uiInput(ctx, msg("setup.app_secret"))).trim();
   }
 
   const groupPolicy = await uiSelect<GroupPolicy>(ctx,
-    "群聊策略 / Group policy",
+    msg("setup.group_policy.title"),
     [
-      { value: "open", label: "open：不需要 @，群/话题消息自动回复 / auto reply without @ in groups/topics" },
-      { value: "mention", label: "mention：只有 @ 机器人才回复 / reply only when mentioned" },
+      { value: "open", label: msg("setup.group_policy.open") },
+      { value: "mention", label: msg("setup.group_policy.mention") },
     ],
     "open",
   );
@@ -78,18 +79,17 @@ export async function runSetup(ctx: ExtensionCommandContext) {
     appSecret,
     domain,
     groupPolicy,
-    language: "zh",
     reactEmoji: DEFAULT_CONFIG.reactEmoji,
     autoStart: true,
   };
   writeJson(CONFIG_PATH, config);
 
   ctx.ui.notify(
-    `飞书配置已保存 / Feishu config saved\nPath: ${CONFIG_PATH}\nApp ID: ${mask(appId)}\n群聊策略 / Group policy: ${groupPolicy}`,
+    t("setup.saved", { path: CONFIG_PATH, id: mask(appId), policy: groupPolicy }),
     "info",
   );
 
-  if (await uiConfirm(ctx, "现在启动飞书连接？ / Start Feishu now?", true)) {
+  if (await uiConfirm(ctx, msg("setup.start_confirm"), true)) {
     return config;
   }
   return undefined;
@@ -97,25 +97,25 @@ export async function runSetup(ctx: ExtensionCommandContext) {
 
 async function registerFeishuApp(ctx: ExtensionCommandContext): Promise<{ appId: string; appSecret: string; domain: Domain }> {
   const lark = await import("@larksuiteoapi/node-sdk");
-  ctx.ui.notify("正在准备飞书授权二维码... / Preparing Feishu authorization QR code...", "info");
+  ctx.ui.notify(msg("setup.preparing_qr"), "info");
 
   const result = await lark.registerApp({
     source: "pi-feishu-extension",
     onQRCodeReady(info: { url: string; expireIn: number }) {
       qrcode.generate(info.url, { small: true }, (qr) => {
-        console.log("\n飞书/Lark 授权二维码 / Feishu/Lark authorization QR code");
+        console.log(msg("setup.qr_header"));
         console.log(qr);
         console.log(info.url);
-        console.log(`二维码 ${info.expireIn} 秒后过期 / QR code expires in ${info.expireIn} seconds.`);
+        console.log(t("setup.qr_expire", { expireIn: info.expireIn }));
       });
       ctx.ui.notify(
-        "请在终端扫描二维码，或打开终端中显示的链接。 / Scan the QR code in terminal, or open the link printed there.",
+        msg("setup.qr_scan_hint"),
         "info",
       );
     },
     onStatusChange(info: any) {
       if (info?.status === "domain_switched") {
-        ctx.ui.notify("检测到 Lark 租户，正在切换区域。 / Detected Lark tenant; switching domain.", "info");
+        ctx.ui.notify(msg("setup.lark_detected"), "info");
       }
     },
   });

--- a/.pi/extensions/feishu/task-status-card.ts
+++ b/.pi/extensions/feishu/task-status-card.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { debugLog } from "./debug.js";
+import { msg, t } from "./locale.js";
 
 export type TaskStatus = "running" | "done" | "failed" | "stopped" | "inactive";
 
@@ -23,7 +24,7 @@ const RUNNING_UPDATE_INTERVAL_MS = 3_000;
 export class TaskStatusCard implements TaskStatusSink {
   readonly runId = randomUUID();
   private cardMessageId: string | undefined;
-  private phase = "开始处理";
+  private phase = msg("task.phase.starting");
   private status: TaskStatus = "running";
   private heartbeat: NodeJS.Timeout | undefined;
   private lastUpdateAt = 0;
@@ -66,7 +67,7 @@ export class TaskStatusCard implements TaskStatusSink {
     void this.updateRunningPhase(phase);
   }
 
-  async stopImmediately(phase = "用户已停止任务") {
+  async stopImmediately(phase = msg("conversation.user_stopped")) {
     await this.finishFinal("stopped", phase, true);
   }
 
@@ -179,7 +180,7 @@ export class TaskStatusCard implements TaskStatusSink {
     this.heartbeat = setInterval(() => {
       if (this.status !== "running") return;
       if (Date.now() - this.lastUpdateAt < STILL_RUNNING_MS) return;
-      void this.updateRunningPhase("仍在处理");
+      void this.updateRunningPhase(msg("task.phase.still_running"));
     }, STILL_RUNNING_MS);
     this.heartbeat.unref?.();
   }
@@ -215,14 +216,14 @@ export function buildTaskStatusCard(input: { key: string; status: TaskStatus; ph
         tag: "div",
         text: {
           tag: "lark_md",
-          content: `当前阶段：${normalizePhase(input.phase)}`,
+          content: t("task.phase.current", { phase: normalizePhase(input.phase) }),
         },
       }] : []),
       ...(running ? [{
         tag: "action",
         actions: [{
           tag: "button",
-          text: { tag: "plain_text", content: "停止任务" },
+          text: { tag: "plain_text", content: msg("task.button.stop") },
           type: "danger",
           value: { action: STOP_ACTION, key: input.key, runId: input.runId },
         }],
@@ -289,11 +290,11 @@ function normalizePhase(text: string) {
 }
 
 function titleForStatus(status: TaskStatus) {
-  if (status === "done") return "任务完成";
-  if (status === "failed") return "任务失败";
-  if (status === "stopped") return "任务已停止";
-  if (status === "inactive") return "任务已结束";
-  return "任务进行中";
+  if (status === "done") return msg("task.status.done");
+  if (status === "failed") return msg("task.status.failed");
+  if (status === "stopped") return msg("task.status.stopped");
+  if (status === "inactive") return msg("task.status.inactive");
+  return msg("task.status.running");
 }
 
 function headerTemplate(status: TaskStatus) {
@@ -306,8 +307,8 @@ function headerTemplate(status: TaskStatus) {
 
 function defaultFinalPhase(status: Exclude<TaskStatus, "running" | "inactive">): string | undefined {
   if (status === "done") return undefined;
-  if (status === "failed") return "处理失败";
-  return "用户已停止任务";
+  if (status === "failed") return msg("task.final_phase.failed");
+  return msg("task.final_phase.stopped");
 }
 
 function sleep(ms: number) {


### PR DESCRIPTION
- Add locale.ts with getLocale() detection (config → FEISHU_LANGUAGE env
  → LANG terminal locale → "en" fallback), msg()/t() translation helpers,
  and joinErrors() locale-aware separator
- Change DEFAULT_CONFIG.language from "zh" to undefined — locale detection
  now runs fresh per process, no hardcoded default
- Remove dead language params from extractMarkdownTitle/markdownToPost;
  unify LocaleKey resolution under getLocale()
- Wire up invalidateLocale() after setup/reset/autostart config changes
- Convert all files: cards, conversation-manager, index, message-handler,
  messages, rich-text, setup, task-status-card, bridge-runtime
