### PR TITLE
fix: 长时间任务不再被误报为失败

### DIFF
--- a/.pi/extensions/feishu/config.ts
+++ b/.pi/extensions/feishu/config.ts
@@ -14,7 +14,7 @@ export const CHILD_SESSION_ENV = "PI_FEISHU_CHILD_SESSION";
 
 export const DEFAULT_CONFIG: Pick<
   FeishuConfig,
-  "domain" | "groupPolicy" | "cardActionMode" | "cardActionWebhookHost" | "cardActionWebhookPort" | "cardActionWebhookPath" | "language" | "reactEmoji" | "autoStart"
+  "domain" | "groupPolicy" | "cardActionMode" | "cardActionWebhookHost" | "cardActionWebhookPort" | "cardActionWebhookPath" | "language" | "reactEmoji" | "autoStart" | "promptNotifySec" | "promptTimeoutSec"
 > = {
   domain: "feishu",
   groupPolicy: "open",
@@ -25,6 +25,8 @@ export const DEFAULT_CONFIG: Pick<
   language: "zh",
   reactEmoji: "THUMBSUP",
   autoStart: true,
+  promptNotifySec: 180,
+  promptTimeoutSec: 0,
 };
 
 export function ensureRoot() {
@@ -66,6 +68,8 @@ export function loadConfig(): FeishuConfig | undefined {
       language: (process.env.FEISHU_LANGUAGE as "zh" | "en") || DEFAULT_CONFIG.language,
       reactEmoji: process.env.FEISHU_REACT_EMOJI || DEFAULT_CONFIG.reactEmoji,
       autoStart: process.env.FEISHU_AUTO_START ? process.env.FEISHU_AUTO_START !== "0" : DEFAULT_CONFIG.autoStart,
+      promptNotifySec: parseEnvSeconds(process.env.FEISHU_PROMPT_NOTIFY_SEC) ?? DEFAULT_CONFIG.promptNotifySec,
+      promptTimeoutSec: parseEnvSeconds(process.env.FEISHU_PROMPT_TIMEOUT_SEC) ?? DEFAULT_CONFIG.promptTimeoutSec,
     };
   }
   if (!existsSync(CONFIG_PATH)) return undefined;
@@ -83,7 +87,19 @@ export function loadConfig(): FeishuConfig | undefined {
     language: cfg.language || DEFAULT_CONFIG.language,
     reactEmoji: cfg.reactEmoji || DEFAULT_CONFIG.reactEmoji,
     autoStart: cfg.autoStart ?? DEFAULT_CONFIG.autoStart,
+    promptNotifySec: numberOr(cfg.promptNotifySec, DEFAULT_CONFIG.promptNotifySec),
+    promptTimeoutSec: numberOr(cfg.promptTimeoutSec, DEFAULT_CONFIG.promptTimeoutSec),
   };
+}
+
+function parseEnvSeconds(value: string | undefined) {
+  if (!value) return undefined;
+  const seconds = Number.parseInt(value, 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : undefined;
+}
+
+function numberOr(value: unknown, fallback: number) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : fallback;
 }
 
 function parseCardActionMode(value: unknown): CardActionMode | undefined {

--- a/.pi/extensions/feishu/conversation-manager.ts
+++ b/.pi/extensions/feishu/conversation-manager.ts
@@ -12,6 +12,7 @@ import {
 import type { FeishuBridgeRuntime } from "./bridge-runtime.js";
 import { CHILD_SESSION_ENV, ensureRoot, readJson, STATE_PATH, writeJson } from "./config.js";
 import { debugLog } from "./debug.js";
+import { waitForPrompt } from "./prompt-timeout.js";
 import type { ResumeScope, ResumeSessionPage } from "./cards.js";
 import type { TaskStatusSink } from "./task-status-card.js";
 import type { FeishuState } from "./types.js";
@@ -21,6 +22,13 @@ type ActiveRun = {
   runId?: string;
   stopped: boolean;
   status?: TaskStatusSink;
+};
+
+export type ConversationTimeouts = {
+  /** Seconds before a long-running task sends a "still working" notice (0 disables). Default 180. */
+  promptNotifySec?: number;
+  /** Hard prompt timeout in seconds; the session is aborted on expiry (0 disables / wait indefinitely). Default 0. */
+  promptTimeoutSec?: number;
 };
 
 export type StopConversationResult =
@@ -43,6 +51,7 @@ export class ConversationManager {
   constructor(
     private readonly cwd: string,
     private readonly bridge?: FeishuBridgeRuntime,
+    private readonly timeouts: ConversationTimeouts = {},
   ) {
     ensureRoot();
     this.state = readJson<FeishuState>(STATE_PATH, { sessions: {} });
@@ -84,12 +93,15 @@ export class ConversationManager {
       this.activeRuns.set(key, run);
       this.bridge?.beginFeishuInput(session.sessionId);
       try {
+        // If a previous turn is still streaming (e.g. the queue advanced while a
+        // long task was running), wait for it instead of erroring with
+        // "Agent is already processing".
+        if (session.isStreaming) {
+          debugLog("feishu.prompt.wait_for_idle", { key });
+          await session.waitForIdle();
+        }
         try {
-          await withTimeout(
-            session.prompt(userText, images.length ? { images } : undefined),
-            180_000,
-            "Pi 模型处理超时，请稍后重试；如果是图片消息，可以先切换到明确支持图片的模型。",
-          );
+          await this.runPromptWithTimeouts(session, userText, images, key, onReply);
         } catch (error) {
           if (run.stopped) {
             debugLog("feishu.prompt.stopped", { key });
@@ -356,14 +368,59 @@ export class ConversationManager {
   }
 
   private previousTurn(key: string) {
-    const previous = this.queues.get(key) || Promise.resolve();
-    return withTimeout(previous, 120_000, "上一条飞书消息处理超时，已跳过等待。")
-      .catch((error) => {
-        debugLog("feishu.queue.previous_timeout", {
-          key,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
+    // Wait for the previous message to finish. Long tasks are allowed to run as
+    // long as they need; the task card stays "running" and /stop can abort at any
+    // time. An arbitrary cap here caused follow-up messages to hit
+    // "Agent is already processing" while the previous turn was still running.
+    return this.queues.get(key) || Promise.resolve();
+  }
+
+  private notifyMs() {
+    const sec = this.timeouts?.promptNotifySec;
+    return typeof sec === "number" && Number.isFinite(sec) && sec > 0 ? sec * 1000 : 0;
+  }
+
+  private hardTimeoutMs() {
+    const sec = this.timeouts?.promptTimeoutSec;
+    return typeof sec === "number" && Number.isFinite(sec) && sec > 0 ? sec * 1000 : 0;
+  }
+
+  /**
+   * Run session.prompt with a non-fatal "still working" notice threshold and an
+   * opt-in hard timeout. Long-running tasks are never reported as failed just
+   * because they take longer than a fixed window; only the configured hard
+   * timeout (promptTimeoutSec > 0) fails, and it aborts the session first so the
+   * run is not left busy in the background.
+   */
+  private async runPromptWithTimeouts(
+    session: AgentSession,
+    userText: string,
+    images: Array<{ type: "image"; data: string; mimeType: string }>,
+    key: string,
+    onReply: (text: string) => Promise<void>,
+  ) {
+    const notifyMs = this.notifyMs();
+    const hardMs = this.hardTimeoutMs();
+    const hardSec = Math.round(hardMs / 1000);
+    await waitForPrompt(session.prompt(userText, images.length ? { images } : undefined), {
+      notifyMs,
+      hardMs,
+      hardTimeoutMessage: `Pi 模型处理超时（超过 ${hardSec} 秒）仍未完成，已中止任务。可点击卡片「停止任务」或调大 config.json 中的 promptTimeoutSec。`,
+      onStillRunning: () => {
+        debugLog("feishu.prompt.notify_still_running", { key, elapsedMs: notifyMs });
+        // The task is not failing — it is still running. Tell the user instead
+        // of the old behaviour which reported a false failure.
+        void onReply("⏳ 任务仍在处理中，没有失败。请耐心等待，也可以点击任务卡片上的「停止任务」中止。")
+          .catch(() => undefined);
+      },
+      onHardTimeout: async () => {
+        debugLog("feishu.prompt.hard_timeout", { key, elapsedMs: hardMs });
+        // Abort the underlying run so the session is not left processing.
+        try {
+          await session.abort();
+        } catch {}
+      },
+    });
   }
 
   private async createSession(key: string): Promise<AgentSession> {
@@ -459,20 +516,6 @@ export class ConversationManager {
     } catch {
       return path;
     }
-  }
-}
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, timeoutMessage: string): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_, reject) => {
-        timer = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
   }
 }
 

--- a/.pi/extensions/feishu/index.ts
+++ b/.pi/extensions/feishu/index.ts
@@ -26,7 +26,11 @@ export default function feishuExtension(pi: ExtensionAPI) {
   const bridgeStore = new FeishuBridgeStore();
   const delivery = new FeishuDelivery(() => transport);
   const bridge = new FeishuBridgeRuntime(bridgeStore, delivery);
-  const conversations = new ConversationManager(process.cwd(), bridge);
+  const bootConfig = loadConfig();
+  const conversations = new ConversationManager(process.cwd(), bridge, {
+    promptNotifySec: bootConfig?.promptNotifySec,
+    promptTimeoutSec: bootConfig?.promptTimeoutSec,
+  });
   const messageHandler = new FeishuMessageHandler(conversations, () => transport, bridgeStore);
 
   const STATUS_KEY = "feishu-connection";
@@ -439,8 +443,6 @@ export default function feishuExtension(pi: ExtensionAPI) {
       }
     },
   });
-
-  const bootConfig = loadConfig();
 
   pi.on("session_start", async (_event, ctx) => {
     uiRef = ctx.ui as any;

--- a/.pi/extensions/feishu/prompt-timeout.ts
+++ b/.pi/extensions/feishu/prompt-timeout.ts
@@ -1,0 +1,67 @@
+export type PromptWatchOptions = {
+  /** After this many ms, fire onStillRunning() once while the prompt is still pending. 0 disables. */
+  notifyMs: number;
+  /** After this many ms, the awaited prompt rejects with an Error carrying hardTimeoutMessage. 0 disables. */
+  hardMs: number;
+  /** Error message used when the hard timeout fires. */
+  hardTimeoutMessage: string;
+  /** Fired once when notifyMs elapses and the prompt is still pending. Must never fail the prompt. */
+  onStillRunning?: () => void;
+  /** Called when the hard timeout fires; use it to abort the underlying run so it is not left busy. */
+  onHardTimeout?: () => Promise<void> | void;
+};
+
+/**
+ * Awaits a prompt promise with an optional "still working" notice threshold and
+ * an optional hard timeout.
+ *
+ * The notify threshold NEVER fails the prompt — it only observes, so long-running
+ * tasks are never reported as failed just because they take a while. Only the
+ * hard timeout (opt-in) rejects, and the caller is expected to abort the
+ * underlying run via onHardTimeout so the session does not keep running in the
+ * background (which would otherwise leave it busy for follow-up messages).
+ */
+export async function waitForPrompt(prompt: Promise<unknown>, options: PromptWatchOptions): Promise<void> {
+  const { notifyMs, hardMs, hardTimeoutMessage, onStillRunning, onHardTimeout } = options;
+
+  if (notifyMs <= 0 && hardMs <= 0) {
+    await prompt;
+    return;
+  }
+
+  let notifyTimer: NodeJS.Timeout | undefined;
+  let hardTimer: NodeJS.Timeout | undefined;
+  let hardReject: ((error: Error) => void) | undefined;
+
+  if (notifyMs > 0) {
+    notifyTimer = setTimeout(() => {
+      onStillRunning?.();
+    }, notifyMs);
+    notifyTimer.unref?.();
+  }
+
+  if (hardMs > 0) {
+    hardTimer = setTimeout(() => {
+      const error = new Error(hardTimeoutMessage);
+      hardReject?.(error);
+      void Promise.resolve(onHardTimeout?.()).catch(() => undefined);
+    }, hardMs);
+    hardTimer.unref?.();
+  }
+
+  try {
+    if (hardMs > 0) {
+      await Promise.race([
+        prompt,
+        new Promise<never>((_, reject) => {
+          hardReject = reject;
+        }),
+      ]);
+    } else {
+      await prompt;
+    }
+  } finally {
+    if (notifyTimer) clearTimeout(notifyTimer);
+    if (hardTimer) clearTimeout(hardTimer);
+  }
+}

--- a/.pi/extensions/feishu/types.ts
+++ b/.pi/extensions/feishu/types.ts
@@ -14,6 +14,10 @@ export type FeishuConfig = {
   language?: "zh" | "en";
   reactEmoji?: string;
   autoStart?: boolean;
+  /** Seconds before a long-running task sends a "still working" notice to chat (0 disables). Default 180. */
+  promptNotifySec?: number;
+  /** Hard prompt timeout in seconds; the session is aborted on expiry (0 disables / wait indefinitely). Default 0. */
+  promptTimeoutSec?: number;
 };
 
 export type ModelSelection = {

--- a/README.md
+++ b/README.md
@@ -239,7 +239,20 @@ Windows PATH 加入 C:\Program Files\Git\bin
 | `FEISHU_CARD_ACTION_WEBHOOK_HOST` | 卡片回调监听地址，默认 `0.0.0.0` |
 | `FEISHU_CARD_ACTION_WEBHOOK_PORT` | 卡片回调端口，默认 `3001` |
 | `FEISHU_CARD_ACTION_WEBHOOK_PATH` | 卡片回调路径，默认 `/webhook/card` |
+| `FEISHU_PROMPT_NOTIFY_SEC` | 长任务超过多少秒后在飞书发一条“仍在处理中”提示，默认 `180`，`0` 关闭 |
+| `FEISHU_PROMPT_TIMEOUT_SEC` | 任务硬超时秒数，超时后中止任务并报失败，默认 `0`（不设硬超时，长期运行也不会被报失败） |
 | `FEISHU_EXT_DEV`      | `1` 时显示本地开发标识 `DEV`           |
+
+### config.json 字段
+
+除了上面的环境变量，也可以在 `config.json` 里设置（优先级：环境变量 > config.json > 默认值）：
+
+| 字段                   | 说明                            |
+| --------------------- | ----------------------------- |
+| `promptNotifySec`     | 长任务超过多少秒后在飞书发一条“仍在处理中”提示，默认 `180`，`0` 关闭 |
+| `promptTimeoutSec`    | 任务硬超时秒数，超时后中止任务并报失败，默认 `0`（不设硬超时，长期运行也不会被报失败） |
+
+> 注意：长时间任务（例如跑测试、构建、批量处理）默认**不会**再被报为“任务失败”——到达 `promptNotifySec` 后只会在飞书里提示“任务仍在处理中”，任务卡片保持“进行中”，完成后正常送达结果。只有显式设置 `promptTimeoutSec` 后才会硬超时。修改后请执行 `/feishu restart` 生效。
 
 ***
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-feishu-lark",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-feishu-lark",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-feishu-lark",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Feishu/Lark bridge for Pi coding agent — chat with Pi from Feishu or Lark",
   "type": "module",
   "license": "MIT",

--- a/tests/prompt-timeout.test.mjs
+++ b/tests/prompt-timeout.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mock } from "node:test";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const { waitForPrompt } = await import(join(repoRoot, ".pi/extensions/feishu/prompt-timeout.ts"));
+
+function deferred() {
+  let resolveFn;
+  let rejectFn;
+  const promise = new Promise((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  return { promise, resolve: resolveFn, reject: rejectFn };
+}
+
+test("resolves when the prompt resolves (no timers configured)", async () => {
+  await waitForPrompt(Promise.resolve("ok"), {
+    notifyMs: 0,
+    hardMs: 0,
+    hardTimeoutMessage: "unused",
+  });
+});
+
+test("fires the still-running notice once but never fails a long prompt", async (t) => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  t.after(() => mock.timers.reset());
+
+  const d = deferred();
+  let notified = 0;
+  const run = waitForPrompt(d.promise, {
+    notifyMs: 1000,
+    hardMs: 0,
+    hardTimeoutMessage: "unused",
+    onStillRunning: () => {
+      notified += 1;
+    },
+  });
+
+  mock.timers.tick(999);
+  assert.equal(notified, 0, "notice must not fire before the threshold");
+
+  mock.timers.tick(1);
+  assert.equal(notified, 1, "notice fires once at the threshold");
+
+  let settled = false;
+  const watcher = run.then(() => {
+    settled = true;
+  });
+  void watcher;
+  await mock.timers.tick(60_000);
+  assert.equal(notified, 1, "notice fires only once");
+  assert.equal(settled, false, "a long prompt must not be settled by the notice");
+
+  d.resolve();
+  await run;
+  assert.equal(notified, 1);
+});
+
+test("does not fire the notice when the prompt finishes early", async () => {
+  let notified = 0;
+  await waitForPrompt(Promise.resolve("fast"), {
+    notifyMs: 1_000_000,
+    hardMs: 0,
+    hardTimeoutMessage: "unused",
+    onStillRunning: () => {
+      notified += 1;
+    },
+  });
+  assert.equal(notified, 0);
+});
+
+test("hard timeout rejects with the timeout message and calls onHardTimeout", async (t) => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  t.after(() => mock.timers.reset());
+
+  const d = deferred();
+  let hardCalls = 0;
+  const run = waitForPrompt(d.promise, {
+    notifyMs: 0,
+    hardMs: 2000,
+    hardTimeoutMessage: "Pi 模型处理超时（超过 2 秒）",
+    onHardTimeout: async () => {
+      hardCalls += 1;
+    },
+  });
+
+  mock.timers.tick(2000);
+  await assert.rejects(run, /Pi 模型处理超时（超过 2 秒）/);
+  assert.equal(hardCalls, 1);
+});
+
+test("hard timeout is cancelled when the prompt resolves first", async () => {
+  let hardCalls = 0;
+  await waitForPrompt(Promise.resolve("fast"), {
+    notifyMs: 0,
+    hardMs: 1000,
+    hardTimeoutMessage: "unused",
+    onHardTimeout: () => {
+      hardCalls += 1;
+    },
+  });
+  assert.equal(hardCalls, 0);
+});
+
+test("a real prompt error propagates untouched", async () => {
+  await assert.rejects(
+    waitForPrompt(Promise.reject(new Error("real-model-error")), {
+      notifyMs: 0,
+      hardMs: 0,
+      hardTimeoutMessage: "unused",
+    }),
+    /real-model-error/,
+  );
+});


### PR DESCRIPTION
## 问题

长时间任务（例如在项目里跑测试/构建/批量处理）超过 **3 分钟**后，飞书会收到"任务失败"，但任务实际并没有失败，还在正常运行。

## 根因

`conversation-manager.ts` 用硬编码的 180 秒超时包裹 `session.prompt()`：

```ts
await withTimeout(session.prompt(...), 180_000, "Pi 模型处理超时…");
```

- `Promise.race` 到 180s 就 reject，扩展向飞书发送"Pi 模型处理超时"并把任务卡片标记为 `failed`
- 但 `Promise.race` **不会取消** 底层 agent，任务继续在后台正常运行
- 最终结果永远丢失；且会话残留占用，后续消息报 `Agent is already processing`

## 修复

1. **移除硬编码 180 秒失败超时**，改为非致命提示：超过 `promptNotifySec`（默认 180s）只在飞书发一条"⏳ 任务仍在处理中，没有失败"，任务卡片保持"进行中"，完成后正常送达结果
2. **新增可配置 `promptTimeoutSec`**（默认 `0` = 不设硬超时）：显式配置后才会硬超时，且会先 `session.abort()` 再报失败，避免会话残留
3. **移除 `previousTurn` 的 120 秒"跳过等待"**：后续消息排队等待长任务完成，配合 `session.waitForIdle()` 避免 `Agent is already processing`
4. 新增 `prompt-timeout.ts` 纯函数 + 6 个单元测试（`node --test` 全部通过，`tsc --noEmit` 通过）

配置项（`~/.pi/agent/feishu/config.json`，也可用环境变量 `FEISHU_PROMPT_NOTIFY_SEC` / `FEISHU_PROMPT_TIMEOUT_SEC`）：

| 字段 | 说明 |
| --- | --- |
| `promptNotifySec` | 超过多少秒后发"仍在处理中"提示，默认 `180`，`0` 关闭 |
| `promptTimeoutSec` | 硬超时秒数，超时后中止任务并报失败，默认 `0`（禁用） |