### PR TITLE
fix(win32): spawn node directly to avoid WSL bash conflict

### DIFF
--- a/.pi/extensions/feishu/index.ts
+++ b/.pi/extensions/feishu/index.ts
@@ -311,12 +311,29 @@ export default function feishuExtension(pi: ExtensionAPI) {
       reapDetachedDaemonProcesses({ keepPids: [process.pid] });
       ensureRoot();
       const logFd = openSync(DAEMON_LOG_PATH, "a");
-      const child = spawn("bash", ["-lc", daemonCommand()], {
-        detached: true,
-        cwd: process.cwd(),
-        env: { ...process.env, PI_FEISHU_DAEMON: "1" },
-        stdio: ["ignore", logFd, logFd],
-      });
+      const { args: daemonArgs } = daemonSpec();
+      let child: ReturnType<typeof spawn>;
+      if (process.platform === "win32") {
+        const npmPrefix = process.env.APPDATA
+          ? `${process.env.APPDATA}\\npm`
+          : `${process.env.USERPROFILE}\\AppData\\Roaming\\npm`;
+        const piCliEntry = process.env.PI_CLI_ENTRY
+          || `${npmPrefix}\\node_modules\\@earendil-works\\pi-coding-agent\\dist\\cli.js`;
+        child = spawn("node", [piCliEntry, ...daemonArgs], {
+          detached: true,
+          cwd: process.cwd(),
+          env: { ...process.env, PI_FEISHU_DAEMON: "1" },
+          stdio: ["pipe", logFd, logFd],
+        });
+        if (child.stdin) { child.stdin.resume(); }
+      } else {
+        child = spawn("bash", ["-lc", daemonCommand()], {
+          detached: true,
+          cwd: process.cwd(),
+          env: { ...process.env, PI_FEISHU_DAEMON: "1" },
+          stdio: ["ignore", logFd, logFd],
+        });
+      }
       child.unref();
 
       await sleep(1500);


### PR DESCRIPTION
## Problem

`/feishu start` and `/feishu restart` fail on Windows PowerShell. The bridge
stays in "已断開 / Disconnected" and the daemon never comes online, even
though the process is spawned.

Reported in #1 with a screenshot.

## Root cause

`.pi/extensions/feishu/index.ts` `startDaemon()` uses:

```ts
spawn("bash", ["-lc", "tail -f /dev/null | exec pi --mode rpc ..."])
```

This fails on Windows for three reasons:

1. **`bash` resolves to WSL's `bash.exe`** at `C:\Windows\System32\bash.exe`,
   not Git Bash. The daemon launches inside WSL with a mismatched Windows
   environment, so module resolution, paths, and credentials all break.

2. **Even with Git Bash in PATH**, the `tail -f /dev/null | exec ...` pipeline
   is unreliable under MinGW; the pipe is rewritten and `exec` may not behave
   as a pure `execve` replacement.

3. **stdin closes** when the pipe finishes. The Linux idiom
   `tail -f /dev/null |` exists specifically to keep stdin open — without it,
   `pi --mode rpc` exits on stdin EOF shortly after launch.

## Fix

Add a `process.platform === "win32"` branch in `startDaemon()`:

- **Spawn `node` directly** with the resolved Pi CLI entry path, bypassing
  the bash pipeline entirely.
- **Resolve the Pi CLI entry** via `process.env.PI_CLI_ENTRY` (override) or
  fall back to `%APPDATA%\npm\node_modules\@earendil-works\pi-coding-agent\dist\cli.js`.
- **Use `stdio: ["pipe", logFd, logFd]`** and call `child.stdin.resume()` to
  keep stdin open — equivalent to the Linux `tail -f /dev/null |` behavior.

The non-Windows path is unchanged.

## Diff summary

```
.pi/extensions/feishu/index.ts | 23 ++-
```

## Testing

Tested on:
- Windows 11 (build 26200.7462)
- PowerShell 7
- Pi v0.78.0
- pi-feishu-lark v0.2.0 / v0.3.1

Before patch: `/feishu start` produces a daemon that immediately exits; status
stays "已断開 / Disconnected".

After patch:
- `node --experimental-strip-types --check` passes
- `/feishu restart` reconnects the bridge
- Incoming Feishu messages receive a reply card

## Why a new PR instead of reviving #5

#5 was a much broader 281-line change covering 4 distinct issues. This PR is
intentionally minimal — it only addresses the spawn/bash issue, which is the
most common Windows failure reported by users. Each remaining concern
(process tree cleanup, autoStart lockout, `isProcessAlive` Windows fix) is a
separate, more invasive change that deserves its own focused review and
testing surface.

## Setup notes for Windows users

After upgrading, Windows users with a previously failed install may also need:

```powershell
# SDK symlink so the daemon process can resolve @larksuiteoapi
New-Item -ItemType Directory -Path "$env:USERPROFILE\.pi\agent\feishu\node_modules" -Force
cmd /c mklink /J "$env:USERPROFILE\.pi\agent\feishu\node_modules\@larksuiteoapi" "$env:USERPROFILE\.pi\agent\npm\node_modules\@larksuiteoapi"

# Clear stale gateway lock from a previous failed start
$lock = "$env:USERPROFILE\.pi\agent\locks.json"
if (Test-Path $lock) {
  $j = Get-Content $lock -Raw | ConvertFrom-Json
  $j.PSObject.Properties.Remove('pi-feishu-lark.feishu-gateway')
  $j | ConvertTo-Json | Set-Content $lock -Encoding UTF8
}
```

These are runtime workarounds, not code changes — the upstream code should not
need additional fixes for them after this PR is merged.

## Credits

Original analysis and fix from @xiaoqizheng0033 in the #1 comment thread.
Packaged as a PR with cleaner structure, commit history, and PR-ready testing
notes.

## Related

- Closes #1
- Related: #5 (broader Windows daemon lifecycle, closed without merge — left
  for a separate, more invasive follow-up)
- Related: #11 (Pi SDK breaking change, separate issue)
