### PR TITLE
fix(feishu_config_set): remove promptGuidelines polluting global system prompt

### DIFF
--- a/.pi/extensions/feishu/index.ts
+++ b/.pi/extensions/feishu/index.ts
@@ -660,11 +660,6 @@ function registerFeishuConfigTools(pi: ExtensionAPI) {
     description:
       `Set a Feishu runtime config key. HOT-RELOADS immediately and persists to runtime-overrides.json — NEVER tell the user to restart the container or edit docker-compose.yml. Allowed keys: ${RUNTIME_CONFIG_KEYS.join(", ")}. Do not set appId/appSecret.`,
     promptSnippet: "Update Feishu group trigger keywords / streaming / emoji at runtime (no restart).",
-    promptGuidelines: [
-      "Only use whitelisted keys; never attempt to set app credentials.",
-      "After set, subsequent group messages use the new settings immediately — no docker restart.",
-      "Never edit docker-compose.yml or env files for these settings; use this tool only.",
-    ],
     parameters: Type.Object({
       key: Type.String({ description: `One of: ${RUNTIME_CONFIG_KEYS.join(", ")}` }),
       value: Type.String({ description: "New value (keywords comma-separated; bool true/false; numbers as digits)" }),


### PR DESCRIPTION
## Problem

The `feishu_config_set` tool registration in `.pi/extensions/feishu/index.ts` uses the `promptGuidelines` field to inject three tool-specific safety rules into the **global** system prompt's Guidelines section — alongside unrelated guidance like *"Be concise in your responses"* and *"Show file paths clearly when working with files"*.

This is a misuse of `promptGuidelines`. That field is for behavioral rules that apply across all turns; the rules here only apply when invoking a single tool. End users see the agent's system prompt visibly polluted with tool-specific instructions that have no business being there.

## Change

Removes the `promptGuidelines: [...]` block from the `feishu_config_set` `registerTool` call (5 lines deleted).

## Why no information is lost

The same safety rules are already in the tool's `description` field, which is the canonical place for them:

> *Set a Feishu runtime config key. HOT-RELOADS immediately and persists to runtime-overrides.json — NEVER tell the user to restart the container or edit docker-compose.yml. Allowed keys: …. Do not set appId/appSecret.*

That single sentence covers all three rules that were in `promptGuidelines`:

| Removed rule | Already in description |
|---|---|
| "Only use whitelisted keys" | "Allowed keys: …" |
| "never attempt to set app credentials" | "Do not set appId/appSecret" |
| "After set, subsequent group messages use the new settings immediately — no docker restart" | "HOT-RELOADS immediately and persists to runtime-overrides.json" |
| "Never edit docker-compose.yml or env files for these settings; use this tool only" | "NEVER tell the user to restart the container or edit docker-compose.yml" |

## Behavior

- No change to end-user behavior. The agent still receives the same safety instructions, just in the tool's description where they belong.
- The other two tools in `registerFeishuConfigTools` (`feishu_config_get`, `feishu_config_clear`) were not using `promptGuidelines`, so they're unaffected.