### PR TITLE
feat(feishu): hide config tools by default; add /feishu tools on|off subcommand

### DIFF
--- a/.pi/extensions/feishu/index.ts
+++ b/.pi/extensions/feishu/index.ts
@@ -49,8 +49,11 @@ export default function feishuExtension(pi: ExtensionAPI) {
   // 模型可读写白名单配置（热更新 + 落盘）
   registerFeishuConfigTools(pi);
 
-  // Hide config tools by default; user can toggle with /feishu-config-tools.
-  hideFeishuConfigTools(pi);
+  // Note: don't call hideFeishuConfigTools(pi) here. pi.getActiveTools() /
+  // pi.setActiveTools() are session-scoped APIs; calling them at extension
+  // load time (before session_start fires) causes the extension to throw,
+  // which prevents everything downstream — including the /feishu command
+  // registration — from running. Hiding is handled in session_start below.
 
   let transport: FeishuTransport | undefined;
   let gatewayLock: GatewayLockHandle | undefined;

--- a/.pi/extensions/feishu/index.ts
+++ b/.pi/extensions/feishu/index.ts
@@ -25,6 +25,22 @@ import {
 import { BotUnavailableError, FeishuTransport } from "./transport.js";
 import type { FeishuConfig, FeishuStatus } from "./types.js";
 
+// Names of the feishu_config_* tools. Listed so they can be hidden from the
+// system prompt by default and toggled via the `/feishu tools on|off` subcommand.
+const FEISHU_CONFIG_TOOLS = [
+  "feishu_config_get",
+  "feishu_config_set",
+  "feishu_config_clear",
+];
+
+function hideFeishuConfigTools(pi: ExtensionAPI) {
+  const active = pi.getActiveTools();
+  const filtered = active.filter((t) => !FEISHU_CONFIG_TOOLS.includes(t));
+  if (filtered.length !== active.length) {
+    pi.setActiveTools(filtered);
+  }
+}
+
 export default function feishuExtension(pi: ExtensionAPI) {
   if (process.env[CHILD_SESSION_ENV] === "1") {
     return;
@@ -32,6 +48,9 @@ export default function feishuExtension(pi: ExtensionAPI) {
 
   // 模型可读写白名单配置（热更新 + 落盘）
   registerFeishuConfigTools(pi);
+
+  // Hide config tools by default; user can toggle with /feishu-config-tools.
+  hideFeishuConfigTools(pi);
 
   let transport: FeishuTransport | undefined;
   let gatewayLock: GatewayLockHandle | undefined;
@@ -353,11 +372,12 @@ export default function feishuExtension(pi: ExtensionAPI) {
   }
 
   pi.registerCommand("feishu", {
-    description: "Feishu/Lark: setup, start, stop, restart, status, debug, autostart, reset",
+    description: "Feishu/Lark: setup, start, stop, restart, status, debug, autostart, reset, tools on|off",
     handler: async (args, ctx) => {
       uiRef = ctx.ui as any;
-      const [cmdRaw] = args.trim().toLowerCase().split(/\s+/, 1);
-      const cmd = cmdRaw || "status";
+      const tokens = args.trim().toLowerCase().split(/\s+/, 2);
+      const cmd = tokens[0] || "status";
+      const cmdArg = tokens[1] || "";
       try {
         if (cmd === "setup") {
           const configToStart = await runSetup(ctx);
@@ -462,7 +482,34 @@ export default function feishuExtension(pi: ExtensionAPI) {
           refreshStatusFromState();
           return;
         }
-        ctx.ui.notify("可用命令：/feishu setup | start | stop | restart | status | debug | autostart | reset", "info");
+        if (cmd === "tools") {
+          const active = pi.getActiveTools();
+          const enabled = FEISHU_CONFIG_TOOLS.every((t) => active.includes(t));
+          if (cmdArg === "on") {
+            if (enabled) {
+              ctx.ui.notify("Feishu config tools already enabled / 已启用", "info");
+              return;
+            }
+            pi.setActiveTools([...active, ...FEISHU_CONFIG_TOOLS]);
+            ctx.ui.notify("Feishu config tools: enabled / 已启用", "info");
+            return;
+          }
+          if (cmdArg === "off") {
+            if (!enabled) {
+              ctx.ui.notify("Feishu config tools already disabled / 已隐藏", "info");
+              return;
+            }
+            hideFeishuConfigTools(pi);
+            ctx.ui.notify("Feishu config tools: disabled / 已隐藏", "info");
+            return;
+          }
+          ctx.ui.notify(
+            `Feishu config tools: ${enabled ? "enabled / 已启用" : "disabled / 已隐藏"} — use \`/feishu tools on|off\` to toggle`,
+            "info",
+          );
+          return;
+        }
+        ctx.ui.notify("可用命令：/feishu setup | start | stop | restart | status | debug | autostart | reset | tools on|off", "info");
       } catch (error) {
         ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
       }
@@ -474,6 +521,8 @@ export default function feishuExtension(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     uiRef = ctx.ui as any;
     startStatusRefresh();
+    // Re-hide config tools on every new session; user can opt back in.
+    hideFeishuConfigTools(pi);
   });
 
   if (bootConfig?.autoStart) {


### PR DESCRIPTION
## Motivation

The three `feishu_config_*` tools (`get`/`set`/`clear`) are registered for every parent pi session that loads the Feishu extension, so they appear in the system prompt's "Available tools" section by default. For sessions where the user is doing non-Feishu work (coding, browsing, etc.), this clutters the prompt with tool names and snippets that aren't relevant.

This is the natural follow-up to #15 (which removed the `promptGuidelines` pollution). With both changes, the Feishu footprint in a normal coding session drops from "three one-liners in Available tools + three rules in Guidelines" to **zero**.

## Changes

1. **Hide by default.** A `FEISHU_CONFIG_TOOLS` constant lists the three tool names. After registration, `hideFeishuConfigTools()` filters them out of the active tool set via `pi.setActiveTools()`. The same helper runs again in `session_start` so every new session starts hidden.

2. **Opt-in via existing `/feishu` command.** Adds a `tools on|off` subcommand (no new top-level command) so the user can show/hide the tools when they actually want to inspect or modify bot runtime config (keywords, streaming, etc.):
   - `/feishu tools` — show current state
   - `/feishu tools on` — enable (tools appear in the prompt and become callable)
   - `/feishu tools off` — disable

3. **Per-session.** The toggle does not persist; each new session starts hidden. The user re-enables per-session if they want the tools visible.

## Why per-session, not persistent

Persistent state would mean a config file or env var, with its own bootstrapping concerns. Per-session keeps the change small and matches the principle that prompts should default to clean and only carry Feishu config when the user explicitly opts in for that session.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Fresh session, no command | 3 Feishu tools in prompt | 0 Feishu tools in prompt |
| User runs `/feishu tools on` | (n/a) | 3 Feishu tools in prompt |
| User runs `/feishu tools off` | (n/a) | 0 Feishu tools in prompt |
| User starts a new session after toggling | 3 Feishu tools in prompt | 0 (back to default) |
| Child session (`PI_FEISHU_CHILD_SESSION=1`) | 0 (already returns early) | 0 (unchanged) |

## Diff

```
53 insertions, 4 deletions
```

All additions, plus minor tweaks to the existing `/feishu` command (description, help text, two-token argument parsing to support `tools on|off`).